### PR TITLE
Fix robots.txt for OCDS documentation

### DIFF
--- a/salt/ocds-docs/robots_live.txt
+++ b/salt/ocds-docs/robots_live.txt
@@ -9,26 +9,13 @@ Disallow: /1.0-dev
 # Different config for Googlebot, as that supports Allows (so we can restrict more)
 User-agent: Googlebot
 Allow: /$
-Allow: /latest$
-Allow: /latest/$
-Allow: /latest/en
-Allow: /latest/es
-Allow: /latest/fr
-Allow: /latest/it
+Allow: /latest
 Allow: /review
-Allow: /infrastructure$
-Allow: /infrastructure/$
-Allow: /infrastructure/latest$
-Allow: /infrastructure/latest/$
-Allow: /infrastructure/latest/en
+Allow: /infrastructure/latest
 Allow: /infrastructure/review
-Allow: /profiles/ppp/$
-Allow: /profiles/ppp/latest$
-Allow: /profiles/ppp/latest/$
-Allow: /profiles/ppp/latest/en
-Allow: /profiles/ppp/latest/es
-Allow: /profiles/eu/master/en/
-Allow: /profiles/gpa/master/en/
+Allow: /profiles/ppp/latest
+Allow: /profiles/eu/master
+Allow: /profiles/gpa/master
 Disallow: /
 
 User-Agent: LinkChecker

--- a/salt/ocds-docs/robots_live.txt
+++ b/salt/ocds-docs/robots_live.txt
@@ -10,12 +10,17 @@ Disallow: /1.0-dev
 User-agent: Googlebot
 Allow: /$
 Allow: /latest
-Allow: /review
 Allow: /infrastructure/latest
-Allow: /infrastructure/review
 Allow: /profiles/ppp/latest
 Allow: /profiles/eu/master
 Allow: /profiles/gpa/master
+Disallow: /latest/switcher
+Disallow: /infrastructure/latest/switcher
+Disallow: /profiles/ppp/latest/switcher
+Disallow: /profiles/eu/master/switcher
+Disallow: /profiles/gpa/master/switcher
+Allow: /review
+Allow: /infrastructure/review
 Disallow: /
 
 User-Agent: LinkChecker

--- a/salt/ocds-docs/robots_live.txt
+++ b/salt/ocds-docs/robots_live.txt
@@ -8,6 +8,7 @@ Disallow: /1.0-dev
 
 # Different config for Googlebot, as that supports Allows (so we can restrict more)
 User-agent: Googlebot
+Allow: /$
 Allow: /latest$
 Allow: /latest/$
 Allow: /latest/en
@@ -15,7 +16,19 @@ Allow: /latest/es
 Allow: /latest/fr
 Allow: /latest/it
 Allow: /review
-Allow: /$
+Allow: /infrastructure$
+Allow: /infrastructure/$
+Allow: /infrastructure/latest$
+Allow: /infrastructure/latest/$
+Allow: /infrastructure/latest/en
+Allow: /infrastructure/review
+Allow: /profiles/ppp/$
+Allow: /profiles/ppp/latest$
+Allow: /profiles/ppp/latest/$
+Allow: /profiles/ppp/latest/en
+Allow: /profiles/ppp/latest/es
+Allow: /profiles/eu/master/en/
+Allow: /profiles/gpa/master/en/
 Disallow: /
 
 User-Agent: LinkChecker


### PR DESCRIPTION
robots.txt is perhaps too clever by half. For two years we haven't been indexing OCDS for PPPs in Google… Anyhow, this should fix it.