### PR TITLE
Small improvements to Apache config for OCDS docs

### DIFF
--- a/salt/apache/ocds-docs-live.conf.include
+++ b/salt/apache/ocds-docs-live.conf.include
@@ -6,7 +6,7 @@
             '/profiles/ppp': {
                 'versions': ['latest', '1.0'],
                 'languages': ['en', 'es'],
-                'excludes': ['extension', 'schema'],
+                'excludes': ['schema', 'extension'],
             },
             '/infrastructure': {
                 'versions': ['latest', '0.9'],
@@ -17,7 +17,7 @@
             '': {
                 'versions': ['latest', '1.1', '1.0'],
                 'languages': ['en', 'es', 'fr', 'it'],
-                'excludes': ['legacy', 'robots.txt', 'schema'],
+                'excludes': ['schema', 'legacy', 'robots.txt'],
                 'cove_backend': pillar.ocds_cove_backend,
                 'stable_sitemap': [['latest', '1.1', '1.0']],
             },
@@ -43,6 +43,12 @@
 
     DocumentRoot {{ documentroot }}
     RewriteMap unescape int:unescape
+
+    SetEnv BANNER /includes/banner_live.html
+    <Location /1.0/>
+        SetEnv BANNER /includes/banner_old.html
+    </Location>
+
     # Needed to proxy to SSL servers.
     SSLProxyEngine on
     # ProxyPreserveHost was on but we need it to be Off, as it makes adding SSL much easier.
@@ -50,28 +56,23 @@
     # With a keepalive, we had problems with headers being interpreted as the start of the response.
     SetEnv proxy-nokeepalive 1
 
-    SetEnv BANNER /includes/banner_live.html
-    <Location /1.0/>
-        SetEnv BANNER /includes/banner_old.html
-    </Location>
-
     # Remember: The Directory directive applies only to static files, not to proxied or redirected paths.
     <Directory {{ documentroot }}>
         Require all granted
         Options Indexes FollowSymLinks IncludesNOEXEC
         AddOutputFilter INCLUDES .html
 
-        {% for root, opts in options.items() %}
-            # Add an "en" language if not present, to avoid serving a directory listing.
-            # Putting this in a Directory directive rather than a Location directive avoids having to exclude /review, etc.
-            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/$ {{ root }}/$1/en/
-        {% endfor %}
-
         # Serve JSON with UTF-8 charset.
         # https://bugs.chromium.org/p/chromium/issues/detail?id=438464
         AddType "application/json; charset=utf-8" .json
 
         Header set Access-Control-Allow-Origin "*"
+
+        {% for root, opts in options.items() %}
+            # Add an "en" language if not present, to avoid serving a directory listing.
+            # Putting this in a Directory directive rather than a Location directive avoids having to exclude /review, etc.
+            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/?$ {{ root }}/$1/en/
+        {% endfor %}
     </Directory>
 
     {% for root, opts in options.items() %}
@@ -94,12 +95,12 @@
                 {% endif %}
                 # Use the HTTP referer to return to the same page in the new version.
                 RewriteCond "%{HTTP_REFERER}:::%{QUERY_STRING}" "^https://([^/]*){{ root }}/([^/]*)/([^/]*)/(.*):::branch=(.*)$"
-                RewriteRule ^(.*)$ {{ root }}/${unescape:%5}/%3/%4? [R]
+                RewriteRule ^.*$ {{ root }}/${unescape:%5}/%3/%4? [R]
             {% endfor %}
 
             # If there is no HTTP referer, or if the branch is legacy, go to the version's homepage.
             RewriteCond "%{QUERY_STRING}" "^branch=(.*)$"
-            RewriteRule ^(.*)$ {{ root }}/${unescape:%1}? [R]
+            RewriteRule ^.*$ {{ root }}/${unescape:%1}/? [R]
         </Location>
 
         {% for version in opts.versions %}
@@ -110,11 +111,11 @@
 
                 # Use the HTTP referer to return to the same page in the new language.
                 RewriteCond "%{HTTP_REFERER}:::%{QUERY_STRING}" "^https://([^/]*){{ root }}/([^/]*)/([^/]*)/(.*):::lang=(.*)$"
-                RewriteRule ^(.*)$ {{ root }}/%2/${unescape:%5}/%4? [R]
+                RewriteRule ^.*$ {{ root }}/%2/${unescape:%5}/%4? [R]
 
                 # If there is no HTTP referer, go to the version's homepage.
                 RewriteCond "%{QUERY_STRING}" "^lang=(.*)$"
-                RewriteRule ^(.*)$ {{ root }}/{{ version }}/${unescape:%1}? [R]
+                RewriteRule ^.*$ {{ root }}/{{ version }}/${unescape:%1}/? [R]
             </Location>
 
             {% for lang in opts.languages %}
@@ -124,6 +125,7 @@
 
                 <Location {{ root }}/{{ version }}/{{ lang }}/404/>
                     SetOutputFilter SUBSTITUTE
+                    # This also substitutes URLs for stylesheets, scripts, etc.
                     Substitute "s|\"\.\./|\"{{ root }}/{{ version }}/{{ lang }}/|i"
                 </Location>
             {% endfor %}
@@ -186,7 +188,7 @@
         {% for root, opts in options.items() %}
             # Add an "en" language if not present, to avoid serving a directory listing.
             # This should be identical to the RedirectMatch directive within the Directory directive above.
-            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/$ {{ root }}/$1/en/
+            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/?$ {{ root }}/$1/en/
         {% endfor %}
     </Proxy>
 

--- a/salt/apache/ocds-docs-live.conf.include
+++ b/salt/apache/ocds-docs-live.conf.include
@@ -20,6 +20,7 @@
                 'excludes': ['schema', 'legacy', 'robots.txt'],
                 'cove_backend': pillar.ocds_cove_backend,
                 'stable_sitemap': [['latest', '1.1', '1.0']],
+                'redirect_excludes': ['profiles'],
             },
         }
     %}
@@ -71,7 +72,7 @@
         {% for root, opts in options.items() %}
             # Add an "en" language if not present, to avoid serving a directory listing.
             # Putting this in a Directory directive rather than a Location directive avoids having to exclude /review, etc.
-            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/?$ {{ root }}/$1/en/
+            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes + opts.get('redirect_excludes', []) %}(?!{{ exclude }}){% endfor %}([^/]+)/?$ {{ root }}/$1/en/
         {% endfor %}
     </Directory>
 
@@ -188,7 +189,7 @@
         {% for root, opts in options.items() %}
             # Add an "en" language if not present, to avoid serving a directory listing.
             # This should be identical to the RedirectMatch directive within the Directory directive above.
-            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/?$ {{ root }}/$1/en/
+            RedirectMatch ^{{ root }}/{% for exclude in opts.excludes + opts.get('redirect_excludes', []) %}(?!{{ exclude }}){% endfor %}([^/]+)/?$ {{ root }}/$1/en/
         {% endfor %}
     </Proxy>
 

--- a/salt/apache/ocds-docs-live.conf.include
+++ b/salt/apache/ocds-docs-live.conf.include
@@ -33,7 +33,7 @@
     {% endif %}
 
     {% if testing %}
-        # We want to disallow all in testing only.
+        {# We want to disallow all in testing only. #}
         Alias /robots.txt "/var/www/html/robots.txt"
         <Location "/robots.txt">
             Order allow,deny
@@ -55,15 +55,15 @@
         SetEnv BANNER /includes/banner_old.html
     </Location>
 
-    {# Remember: The Directory directive applies only to static files, not to proxied or redirected paths. #}
+    # Remember: The Directory directive applies only to static files, not to proxied or redirected paths.
     <Directory {{ documentroot }}>
         Require all granted
         Options Indexes FollowSymLinks IncludesNOEXEC
         AddOutputFilter INCLUDES .html
 
         {% for root, opts in options.items() %}
-            {# Putting this in a Directory directive rather than a Location directive avoids having to exclude /review, etc. #}
             # Add an "en" language if not present, to avoid serving a directory listing.
+            # Putting this in a Directory directive rather than a Location directive avoids having to exclude /review, etc.
             RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/$ {{ root }}/$1/en/
         {% endfor %}
 
@@ -76,12 +76,12 @@
 
     {% for root, opts in options.items() %}
         <Location {{ root or '/' }}>
-            {# The trailing slash is optional, to avoid proxying whether present or absent. #}
             # Add a "latest" version if not present.
+            # The trailing slash is optional, to avoid proxying whether present or absent.
             RedirectMatch ^{{ root }}/?$ {{ root }}/latest/
         </Location>
 
-        {# Below, we match QUERY_STRING and HTTP_REFERER in the same RewriteCond for backreferences to work. #}
+        # Below, we match QUERY_STRING and HTTP_REFERER in the same RewriteCond for backreferences to work.
 
         <Location {{ root }}/switcher>
             RewriteEngine on
@@ -134,7 +134,7 @@
         {% endfor %}
 
         {% if 'cove_backend' in opts %}
-            {# /media contains user-submitted content #}
+            # /media contains user-submitted content.
             ProxyPass {{ root }}/review {{ opts.cove_backend }}{{ root }}/review timeout={{ pillar.cove.apache_on_docs_server_proxy_timeout }}
             ProxyPass {{ root }}/static {{ opts.cove_backend }}{{ root }}/static
             ProxyPass {{ root }}/media  {{ opts.cove_backend }}{{ root }}/media
@@ -184,8 +184,8 @@
         RedirectMatch ^/validator/(.*)$ /review/$1
 
         {% for root, opts in options.items() %}
-            {# This should be identical to the RedirectMatch directive within the Directory directive above. #}
             # Add an "en" language if not present, to avoid serving a directory listing.
+            # This should be identical to the RedirectMatch directive within the Directory directive above.
             RedirectMatch ^{{ root }}/{% for exclude in opts.excludes %}(?!{{ exclude }}){% endfor %}([^/]+)/$ {{ root }}/$1/en/
         {% endfor %}
     </Proxy>
@@ -198,7 +198,7 @@
     # Proxy everything else.
     ProxyPass / https://staging.standard.open-contracting.org/
 
-    {# See https://crm.open-contracting.org/issues/4401 #}
+    # See: https://crm.open-contracting.org/issues/4401
     {% for lang in options[''].languages %}
         {% for version in ['latest', '1.1'] %}
             Redirect /{{ version }}/{{ lang }}/extensions/community/            https://extensions.open-contracting.org/{{ lang }}/extensions/

--- a/salt/apache/ocds-docs-live.conf.include
+++ b/salt/apache/ocds-docs-live.conf.include
@@ -44,11 +44,19 @@
         </Location>
     {% endif %}
 
+    DocumentRoot {{ documentroot }}
+    RewriteMap unescape int:unescape
     # Needed to proxy to SSL servers.
     SSLProxyEngine on
+    # ProxyPreserveHost was on but we need it to be Off, as it makes adding SSL much easier.
+    ProxyPreserveHost Off
+    # With a keepalive, we had problems with headers being interpreted as the start of the response.
+    SetEnv proxy-nokeepalive 1
 
-    DocumentRoot {{ documentroot }}
     SetEnv BANNER /includes/banner_live.html
+    <Location /1.0/>
+        SetEnv BANNER /includes/banner_old.html
+    </Location>
 
     {# Remember: The Directory directive applies only to static files, not to proxied or redirected paths. #}
     <Directory {{ documentroot }}>
@@ -67,13 +75,6 @@
 
         Header set Access-Control-Allow-Origin "*"
     </Directory>
-
-    <Directory {{ documentroot }}legacy/>
-        Options +IncludesNOEXEC
-        AddOutputFilter INCLUDES .html
-    </Directory>
-
-    RewriteMap unescape int:unescape
 
     {% for root, opts in options.items() %}
         <Location {{ root }}/>
@@ -138,24 +139,12 @@
         {% endif %}
 
         {% if opts.cove_backend %}
+            {# /media contains user-submitted content #}
             ProxyPass {{ root }}/review {{ opts.cove_backend }}{{ root }}/review timeout={{ pillar.cove.apache_on_docs_server_proxy_timeout }}
             ProxyPass {{ root }}/static {{ opts.cove_backend }}{{ root }}/static
-            {# /media contains user-submitted content #}
             ProxyPass {{ root }}/media  {{ opts.cove_backend }}{{ root }}/media
-            ProxyPass {{ root }}/i18n   {{ opts.cove_backend }}{{ root }}/i18n
-
-            {# This solves a problem - "Convert to Spreadsheet" was working on HTTPS but not HTTP. Fix this by forcing header to be something the CRSF check likes. #}
-            {# When we change HTTPS to force, there will be no HTTP traffic and this block should be removed. #}
-            <Location {{ root }}/review>
-                Header add referer "https://{{ fqdn }}"
-                RequestHeader set referer "https://{{ fqdn }}"
-            </Location>
         {% endfor %}
     {% endfor %}
-
-    <Location /1.0/>
-        SetEnv BANNER /includes/banner_old.html
-    </Location>
 
     # This block applies only to requests that would be proxied to the staging server.
     <Proxy https://staging.standard.open-contracting.org/>
@@ -206,18 +195,14 @@
         RedirectMatch ^/(?!robots\.txt)(?!legacy)(?!schema)([^/]+)/?$ /$1/en/
     </Proxy>
 
-    # With a keepalive, we had problems with headers being interpreted as the start of the response.
-    SetEnv proxy-nokeepalive 1
-
+    # Exceptions, in addition to those for each documentation website above.
     ProxyPass /.well-known/acme-challenge !
     ProxyPass /includes !
     ProxyPass /legacy !
     ProxyPass /robots.txt !
     ProxyPass /switcher !
 
-    # ProxyPreserveHost was on but we need it to be Off, as it makes adding SSL much easier.
-    ProxyPreserveHost Off
-
+    # Proxy everything else.
     ProxyPass / https://staging.standard.open-contracting.org/
 
     {# See https://crm.open-contracting.org/issues/4401 #}

--- a/salt/apache/ocds-docs-live.conf.include
+++ b/salt/apache/ocds-docs-live.conf.include
@@ -24,12 +24,6 @@
     {% set documentroot = '/home/ocds-docs/web/' %}
 
     {% if testing %}
-        {% set fqdn = 'testing.live.standard.open-contracting.org' %}
-    {% else %}
-        {% set fqdn = 'standard.open-contracting.org' %}
-    {% endif %}
-
-    {% if testing %}
         {# Add any configuration specific to the testing virtual host here. #}
     {% else %}
         {# Add any configuration specific to the live virtual host here. #}

--- a/salt/apache/ocds-docs-staging.conf.include
+++ b/salt/apache/ocds-docs-staging.conf.include
@@ -1,14 +1,12 @@
 # vi: ft=apache
 
-    {% if testing  %}
-        # If you have some config you only want on the testing site, use this ....
-    {% endif %}
-    {% if not testing %}
-        # If you have some config you only want on the live site, use this ....
+    {% if testing %}
+        {# Add any configuration specific to the testing virtual host here. #}
+    {% else %}
+        {# Add any configuration specific to the live virtual host here. #}
     {% endif %}
 
-
-    {% set documentroot='/home/ocds-docs/web/' %}
+    {% set documentroot = '/home/ocds-docs/web' %}
     DocumentRoot {{ documentroot }}
 
     SetEnv BANNER /includes/banner_staging.html
@@ -40,7 +38,7 @@
 
         # If our http referer regex failed for some reason:
         RewriteCond "%{QUERY_STRING}" "^lang=(.+)$"
-        RewriteRule ^{{ documentroot }}(profiles/[^/]*/)?([^/]+)/(.*)$ /$1$2/${unescape:%1}? [R]
+        RewriteRule ^(profiles/[^/]*/)?([^/]+)/(.*)$ /$1$2/${unescape:%1}? [R]
     </LocationMatch>
     <LocationMatch /([^/]*/[^/]*)/404/>
         SetOutputFilter SUBSTITUTE

--- a/salt/apache/ocds-docs-staging.conf.include
+++ b/salt/apache/ocds-docs-staging.conf.include
@@ -1,109 +1,73 @@
 # vi: ft=apache
 
+    {% set pattern = '(profiles/[^/]+/|infrastructure/)?' %}
+    {% set documentroot = '/home/ocds-docs/web' %}
+
     {% if testing %}
         {# Add any configuration specific to the testing virtual host here. #}
     {% else %}
         {# Add any configuration specific to the live virtual host here. #}
     {% endif %}
 
-    {% set documentroot = '/home/ocds-docs/web' %}
-    DocumentRoot {{ documentroot }}
-
-    SetEnv BANNER /includes/banner_staging.html
-
-    {% set infrastructure_live_versions = ['latest'] %}
-    {% set langs = ['en', 'es', 'fr'] %}
-    {% set langs_ppp = ['en', 'es'] %}
+    # Note: RewriteRule directives match against, e.g. "/home/ocds-docs/web/profiles/ppp/1.0-dev/switcher".
 
     Alias /robots.txt "/var/www/html/robots.txt"
     <Location "/robots.txt">
-            Order allow,deny
-            Allow from all
+        Order allow,deny
+        Allow from all
     </Location>
 
-    <Location /error/404>
-        RewriteEngine on
-        RewriteCond %{THE_REQUEST} "^[^ ]* (/profiles/[^/]*)?(/[^/]*/[^/]*/)"
-        RewriteRule ^(.*)$ %1%2/404/ [L]
-    </Location>
+    DocumentRoot {{ documentroot }}
     RewriteMap unescape int:unescape
-    <LocationMatch /(profiles/[^/]*/)?[^/]+/switcher>
-        RewriteEngine on
-        # Try using the referer to take you back to the same page in the
-        # different version.
-        # We match QUERY_STRING and HTTP_REFERER in the same RewriteCond as
-        # it's only possible to backreference the most recent RewriteCond
-        RewriteCond "%{HTTP_REFERER}:::%{QUERY_STRING}" "^https?://([^/]*)/(profiles/[^/]*/)?([^/]*)/([^/]*)/(.*):::lang=(.*)$"
-        RewriteRule ^(.*)$ /%2%3/${unescape:%6}/%5? [R]
 
-        # If our http referer regex failed for some reason:
-        RewriteCond "%{QUERY_STRING}" "^lang=(.+)$"
-        RewriteRule ^(profiles/[^/]*/)?([^/]+)/(.*)$ /$1$2/${unescape:%1}? [R]
-    </LocationMatch>
-    <LocationMatch /([^/]*/[^/]*)/404/>
-        SetOutputFilter SUBSTITUTE
-        Substitute "s|\"\.\./|\"error_redirect/|i"
-    </LocationMatch>
-    <LocationMatch "(/profiles/[^/]*)?/([^/]*/[^/]*)/(.*/)?error_redirect/(.*)">
-        RewriteEngine on
-        RewriteCond "%{REQUEST_URI}" "(/profiles/[^/]*)?/([^/]*/[^/]*)/(.*/)?error_redirect/(.*)"
-        RewriteRule ^(.*)$ %1/%2/%4 [R]
-    </LocationMatch>
-
-    <Location /1.0-dev-fake-old/>
-        SetEnv BANNER /includes/banner_old.html
-    </Location>
-
+    SetEnv BANNER /includes/banner_staging.html
     <Location /profiles/ppp/>
         SetEnv BANNER /includes/banner_staging_profiles_ppp.html
     </Location>
-    <LocationMatch /profiles/ppp/(?!master)>
-        # Inflate and deflate here to ensure that the message is not
-        # compressed when we do the substitution, but is afterwards.
-        # I think this may be adding some extra overhead, but for our
-        # dev site this shouldn't be noticeable.
-        AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
-        Substitute "s|<body([^>]*)>|<body$1><div style=\"background-color:red; color: black; width: 100%; text-align: center; font-weight: bold; position: fixed; right: 0; left: 0; z-index: 1031\">This is a dev copy of these docs.</div>|i"
-    </LocationMatch>
-
-    <Location /infrastructure/switcher>
-        RewriteEngine on
-        # Try using the referer to take you back to the same page in the
-        # different version.
-        # We match QUERY_STRING and HTTP_REFERER in the same RewriteCond as
-        # it's only possible to backreference the most recent RewriteCond
-        RewriteCond "%{HTTP_REFERER}:::%{QUERY_STRING}" "^https?://([^/]*)/infrastructure/([^/]*)/([^/]*)/(.*):::branch=(.*)$"
-        RewriteRule ^(.*)$ /infrastructure/${unescape:%5}/%3/%4? [R]
-
-        # If our http referer regex failed for some reason:
-        RewriteCond "%{QUERY_STRING}" "^branch=(.*)$"
-        RewriteRule ^(.*)$ /infrastructure/${unescape:%1}? [R]
-    </Location>
-
-    {% for infrastructure_version in infrastructure_live_versions %}
-        <Location /infrastructure/{{infrastructure_version}}/switcher>
-            RewriteEngine on
-            # Try using the referer to take you back to the same page in the
-            # different version.
-            # We match QUERY_STRING and HTTP_REFERER in the same RewriteCond as
-            # it's only possible to backreference the most recent RewriteCond
-            RewriteCond "%{HTTP_REFERER}:::%{QUERY_STRING}" "^https?://([^/]*)/infrastructure/([^/]*)/([^/]*)/(.*):::lang=(.*)$"
-            RewriteRule ^(.*)$ /infrastructure/{{infrastructure_version}}/${unescape:%5}/%4? [R]
-
-            RewriteCond "%{QUERY_STRING}" "^lang=(.*)$"
-            RewriteRule ^(.*)$ /infrastructure/{{infrastructure_version}}/${unescape:%1}? [R]
-        </Location>
-    {% endfor %}
 
     <Directory {{ documentroot }}>
         Require all granted
         Options Indexes FollowSymLinks IncludesNOEXEC
         AddOutputFilter INCLUDES .html
-        AddType "application/json;charset=utf-8" .json
-        ErrorDocument 404 /error/404
 
-        # This Header directive is in the Directory section to ensure it only
-        # applies to static files, so there's no risk of XSS.
+        # Serve JSON with UTF-8 charset.
+        # https://bugs.chromium.org/p/chromium/issues/detail?id=438464
+        AddType "application/json; charset=utf-8" .json
+
         Header set Access-Control-Allow-Origin "*"
+
+        ErrorDocument 404 /error/404
     </Directory>
 
+    # We can't set 404 pages for individual branches like on the live server, so we use a RewriteRule directive.
+    # Note: Using REQUEST_URI instead of THE_REQUEST breaks behavior.
+    <Location /error/404>
+        RewriteEngine on
+        RewriteCond "%{THE_REQUEST}" "^GET /{{ pattern }}([^/]*/[^/]*)/"
+        RewriteRule ^.*$ /%1%2/404/ [L]
+    </Location>
+
+    # We can't backreference a LocationMatch regular expression, so we need this intermediate step.
+    # Note: Using ^ or $ anchors breaks behavior.
+    <LocationMatch "/{{ pattern }}[^/]*/[^/]*/404/">
+        SetOutputFilter SUBSTITUTE
+        # This also substitutes URLs for stylesheets, scripts, etc.
+        Substitute "s|\"\.\./|\"error_redirect/|i"
+    </LocationMatch>
+
+    # This also handles requests for stylesheets, scripts, etc.
+    <LocationMatch "^/{{ pattern }}[^/]*/[^/]*/(.*/)?error_redirect/.*$">
+        RewriteEngine on
+        RewriteCond "%{REQUEST_URI}" "^/{{ pattern }}([^/]*/[^/]*)/(.*/)?error_redirect/(.*)"
+        RewriteRule ^.*$ https://standard.open-contracting.org/%1%2/%4 [R]
+    </LocationMatch>
+
+    <LocationMatch "^/{{ pattern }}[^/]*/switcher$">
+        RewriteEngine on
+
+        RewriteCond "%{HTTP_REFERER}:::%{QUERY_STRING}" "^https://([^/]*)/{{ pattern }}([^/]*)/([^/]*)/(.*):::lang=(.*)$"
+        RewriteRule ^.*$ https://standard.open-contracting.org/%2%3/${unescape:%6}/%5? [R]
+
+        RewriteCond "%{QUERY_STRING}" "^lang=(.*)$"
+        RewriteRule ^{{ documentroot }}/{{ pattern }}([^/]*) https://standard.open-contracting.org/$1$2/${unescape:%1}/? [R]
+    </LocationMatch>

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -272,3 +272,11 @@ def test_redirect(path, location):
 
     assert r.status_code == 302
     assert r.headers['Location'] == location
+
+
+@pytest.mark.parametrize('suffix', ['', '/'])
+def test_profiles(suffix):
+    r = get('{}/profiles{}'.format(base_url, suffix))
+
+    assert r.status_code == 200
+    assert 'Parent Directory' in r.text


### PR DESCRIPTION
Builds on #47, Closes #2

Make Apache config for OCDS docs easier to read.

- Collect unique statements near top of file.
- Put banner statements together.

Also remove:

- ProxyPass for /i18n, which as far as I can tell is not / no longer returned by the Data Review Tool.
- legacy Directory directive, which already inherits its contents from the other Directory directive.
- review Location directive, as HTTPS is now forced and it can be removed per comments.

----

I'm not sure if order of precendence affects any of the above (I think not?).