### PR TITLE
Rename ocdskit-web to toucan where this would have no impact on deployments

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -27,9 +27,9 @@ base:
      - live_pillar
      - private.ocds_redash_pillar
 
-  'ocdskit-web':
+  'toucan':
      - live_pillar
-     - ocdskit_web_pillar
+     - toucan_pillar
      - private.toucan_pillar
 
   'ocds-kingfisher-archive':

--- a/pillar/toucan_pillar.sls
+++ b/pillar/toucan_pillar.sls
@@ -1,2 +1,2 @@
-ocdskit_web:
+toucan:
   default_branch: 'master'

--- a/salt-config/roster
+++ b/salt-config/roster
@@ -5,7 +5,7 @@ ocds-docs-staging:        staging.docs.opencontracting.uk0.bigv.io
 ocds-docs-live:           live.docs.opencontracting.uk0.bigv.io
 standard-search:          live.standard-search.opencontracting.uk0.bigv.io
 ocds-redash:              live.redash.opencontracting.uk0.bigv.io
-ocdskit-web:              live.toucan.opencontracting.uk0.bigv.io
+toucan:                   live.toucan.opencontracting.uk0.bigv.io
 ocds-kingfisher-archive:  archive.kingfisher.open-contracting.org
 cove-live-ocds-2:         live.cove.opencontracting.uk0.bigv.io
 cove-live-oc4ids:         cove-live.oc4ids.opencontracting.uk0.bigv.io

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -37,8 +37,8 @@ base:
     - ocds-redash
     - prometheus-client-nginx
 
-  'ocdskit-web':
-    - ocdskit-web
+  'toucan':
+    - toucan
     - prometheus-client-apache
 
   'ocds-kingfisher-archive':

--- a/salt/toucan.sls
+++ b/salt/toucan.sls
@@ -1,3 +1,6 @@
+# Toucan used to be named ocdskit-web. We have not yet changed occurrences of r'ocskit.web' where a simple rename would
+# cause a doubling of users, directories, config files, etc.
+
 {% from 'lib.sls' import createuser, private_keys, apache, uwsgi %}
 
 include:
@@ -10,7 +13,7 @@ include:
 {% set user = 'ocdskit-web' %}
 {{ createuser(user) }}
 
-ocdskit-web-deps:
+toucan-deps:
     apache_module.enabled:
       - name: proxy proxy_uwsgi
       - watch_in:
@@ -25,11 +28,11 @@ ocdskit-web-deps:
         - service: apache2
         - service: uwsgi
 
-{% set giturl = 'https://github.com/open-contracting/ocdskit-web.git' %}
+{% set giturl = 'https://github.com/open-contracting/toucan.git' %}
 {% set userdir = '/home/' + user %}
 {% set ocdskitwebdir = userdir + '/ocdskit-web/' %}
 
-{% macro ocdskit_web(name, branch, giturl, user, servername, https='') %}
+{% macro toucan(name, branch, giturl, user, servername, https='') %}
 
 {% set djangodir='/home/'+user+'/'+name+'/' %}
 
@@ -72,7 +75,7 @@ bare_name: {{ name }}
     - system_site_packages: False
     - pip_pkgs: pip==8.1.2
     - require:
-      - pkg: ocdskit-web-deps
+      - pkg: toucan-deps
       - git: {{ giturl }}{{ djangodir }}
 
 # Then install the rest of our requirements
@@ -139,9 +142,9 @@ collectstatic-{{name}}:
 
 {% endmacro %}
 
-{{ ocdskit_web(
+{{ toucan(
     name='ocdskit-web',
-    branch=pillar.ocdskit_web.default_branch,
+    branch=pillar.toucan.default_branch,
     giturl=giturl,
     user=user,
     servername='toucan.open-contracting.org',


### PR DESCRIPTION
I did the easy renaming related to #35. We can leave that issue open for the renames that involve  moving / deleting old directories, config files, users, etc.