### PR TITLE
docs: We don't need python-concurrent.futures python-msgpack any more

### DIFF
--- a/docs/deploy/create_server.rst
+++ b/docs/deploy/create_server.rst
@@ -37,11 +37,6 @@ Bytemark
 
    #. Connect to the server over SSH
    #. Change the password of the root user, using the ``passwd`` command. Use a `strong password <https://www.lastpass.com/password-generator>`__, and save it to OCP's `LastPass <https://www.lastpass.com>`__ account.
-   #. Install packages for Agentless Salt:
-
-      .. code-block:: bash
-
-         apt-get install python-concurrent.futures python-msgpack
 
 #. Update this repository:
 


### PR DESCRIPTION
https://github.com/open-contracting/deploy/issues/16