### PR TITLE
Adding support for new maintenance set up repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Private repositories
 /pillar/private
 /salt/private
+/salt/maintenance
 # Files created by script/setup
 /salt-config/master.d
 /salt-config/pki

--- a/docs/develop/get_started.rst
+++ b/docs/develop/get_started.rst
@@ -30,6 +30,7 @@ You must first have access to two private repositories. Contact an owner of the 
     git clone git@github.com:open-contracting/deploy.git
     git clone git@github.com:open-contracting/deploy-salt-private.git deploy/salt/private
     git clone git@github.com:open-contracting/deploy-pillar-private.git deploy/pillar/private
+    git clone git@github.com:open-contracting/dogsbody-maintenance.git deploy/salt/maintenance
 
 3. Add public key to remote servers
 -----------------------------------

--- a/docs/develop/get_started.rst
+++ b/docs/develop/get_started.rst
@@ -23,7 +23,7 @@ You must use Salt with Python 3. If your system package uses Python 2, install s
 2. Clone repositories
 ---------------------
 
-You must first have access to two private repositories. Contact an owner of the open-contracting organization on GitHub for access. Then:
+You must first have access to three private repositories. Contact an owner of the open-contracting organization on GitHub for access. Then:
 
 .. code-block:: bash
 

--- a/pillar/common_pillar.sls
+++ b/pillar/common_pillar.sls
@@ -7,3 +7,7 @@ system_contacts:
 
   # Email contact for crons
   cron_admin: "sysadmin@open-contracting.org,code@opendataservices.coop,sysadmin@dogsbody.com"
+
+  maintenance: 
+    enabled: false
+

--- a/pillar/cove_oc4ids_live_maintenance.sls
+++ b/pillar/cove_oc4ids_live_maintenance.sls
@@ -1,0 +1,3 @@
+maintenance:
+  enabled: true
+  patching: manual

--- a/pillar/cove_ocds_live3_maintenance.sls
+++ b/pillar/cove_ocds_live3_maintenance.sls
@@ -1,0 +1,3 @@
+maintenance:
+  enabled: true
+  patching: manual

--- a/pillar/kingfisher_process1_maintenance.sls
+++ b/pillar/kingfisher_process1_maintenance.sls
@@ -1,0 +1,8 @@
+maintenance:
+  enabled: true
+  patching: manual
+  rkhunter_customisation: |
+    ALLOWDEVFILE=/dev/shm/PostgreSQL.*
+  hardware_sensors: true
+  custom_sensors:
+    - coretemp

--- a/pillar/ocds_docs_live_maintenance.sls
+++ b/pillar/ocds_docs_live_maintenance.sls
@@ -1,0 +1,3 @@
+maintenance:
+  enabled: true
+  patching: manual

--- a/pillar/ocds_docs_staging_maintenance.sls
+++ b/pillar/ocds_docs_staging_maintenance.sls
@@ -1,0 +1,5 @@
+maintenance:
+  enabled: true
+  patching: manual
+  rkhunter_customisation: |
+    DISABLE_TESTS=properties

--- a/pillar/ocdskingfisher_archive_maintenance.sls
+++ b/pillar/ocdskingfisher_archive_maintenance.sls
@@ -1,0 +1,8 @@
+maintenance:
+  enabled: true
+  patching: manual
+  rkhunter_customisation: |
+    ALLOWDEVFILE=/dev/shm/PostgreSQL.*
+  hardware_sensors: true
+  custom_sensors:
+    - coretemp

--- a/pillar/ocdskingfisher_replica1_maintenance.sls
+++ b/pillar/ocdskingfisher_replica1_maintenance.sls
@@ -1,0 +1,8 @@
+maintenance:
+  enabled: true
+  patching: manual
+  rkhunter_customisation: |
+    ALLOWDEVFILE=/dev/shm/PostgreSQL.*
+  hardware_sensors: true
+  custom_sensors:
+    - coretemp

--- a/pillar/prometheus_maintenance.sls
+++ b/pillar/prometheus_maintenance.sls
@@ -1,0 +1,3 @@
+maintenance:
+  enabled: true
+  patching: manual

--- a/pillar/redash2_maintenance.sls
+++ b/pillar/redash2_maintenance.sls
@@ -1,0 +1,3 @@
+maintenance:
+  enabled: true
+  patching: manual

--- a/pillar/standard-search_maintenance.sls
+++ b/pillar/standard-search_maintenance.sls
@@ -1,0 +1,5 @@
+maintenance:
+  enabled: true
+  patching: manual
+  rkhunter_customisation: |
+    ALLOWHIDDENDIR=/etc/.java

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -54,6 +54,9 @@ base:
     - ocdskingfisher_live_pillar
     - private.ocdskingfisher_live_pillar
     - tinyproxy_pillar
+  
+  'kingfisher-process1':
+    - kingfisher_process1_maintenance
 
   'kingfisher-replica*':
     - ocdskingfisher_replica_live_pillar

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -7,35 +7,42 @@ base:
 
   'ocds-docs-live':
     - ocds_docs_live_pillar
+    - ocds_docs_live_maintenance
 
   'ocds-docs-staging':
     - ocds_docs_staging_pillar
     - tinyproxy_pillar
+    - ocds_docs_staging_maintenance
 
   'standard-search':
     - django_pillar
     - standard_search_pillar
     - private.standard_search_pillar
+    - standard-search_maintenance
 
   'toucan':
     - django_pillar
     - toucan_pillar
     - private.toucan_pillar
+    - toucan_maintenance
 
   'kingfisher-archive':
     - ocdskingfisher_archive_live_pillar
+    - ocdskingfisher_archive_maintenance
 
   'cove-live-oc4ids':
     - django_pillar
     - cove_pillar
     - cove_oc4ids_live_pillar
     - private.cove_oc4ids_live_pillar
+    - cove_oc4ids_live_maintenance
 
   'cove-live-ocds-3':
     - django_pillar
     - cove_pillar
     - cove_ocds_live3_pillar
     - private.cove_ocds_live_pillar
+    - cove_ocds_live3_maintenance
 
   'cove-dev-*':
     - django_pillar
@@ -50,6 +57,11 @@ base:
 
   'kingfisher-replica*':
     - ocdskingfisher_replica_live_pillar
+    - ocdskingfisher_replica1_maintenance
+
+  'prometheus'
+    - prometheus_maintenance 
 
   'redash2':
     - redash
+    - redash2_maintenance

--- a/pillar/toucan_maintenance.sls
+++ b/pillar/toucan_maintenance.sls
@@ -1,0 +1,3 @@
+maintenance:
+  enabled: true
+  patching: manual

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -64,3 +64,11 @@ base:
   'prometheus':
     - prometheus-client-apache
     - prometheus-server
+
+  'maintenance:enabled:true':
+    - match: pillar
+    - maintenance.hardware_sensors
+    - maintenance.patching
+    - maintenance.postgres_monitoring
+    - maintenance.raid_monitoring
+    - maintenance.rkhunter

--- a/script/update
+++ b/script/update
@@ -18,3 +18,9 @@ cd salt/private
 git checkout master
 git pull --rebase origin master
 cd ../..
+
+echo "------------------- deploy/salt/maintenance"
+cd salt/maintenance
+git checkout master
+git pull --rebase origin master
+cd ../..


### PR DESCRIPTION
This PR adds in a new private repo containing a number of salt scripts that set up maintenance. 
You can see these salt scripts here: https://github.com/open-contracting/dogsbody-maintenance

@JimACarter, please can you review the linked salt code.
