### PR TITLE
Point back to prometheus-community/node-exporter-textfile-collector-scripts

### DIFF
--- a/salt/prometheus-client-common.sls
+++ b/salt/prometheus-client-common.sls
@@ -61,7 +61,7 @@ prometheus-node-exporter:
 
 /home/{{ user }}/node-exporter-textfile-collector-scripts:
   git.latest:
-    - name: https://github.com/open-contracting/node-exporter-textfile-collector-scripts
+    - name: https://github.com/prometheus-community/node-exporter-textfile-collector-scripts
     - user: {{ user }}
     - force_fetch: True
     - force_reset: True


### PR DESCRIPTION
Our PR has now been accepted.  We were tracking the remote repo before we needed to make a change https://github.com/open-contracting/node-exporter-textfile-collector-scripts/commit/4bb930b565879696245f006e737b9e1ce6b3bd6d.  I imagine we'd like to go back to the remote repo so we can receive any updates they have?

I've opened this as a PR as I wasn't sure if we'd want to also delete https://github.com/open-contracting/node-exporter-textfile-collector-scripts and update https://github.com/open-contracting/standard-maintenance-scripts/blob/master/badges.md to point to https://github.com/prometheus-community/node-exporter-textfile-collector-scripts instead?