### PR TITLE
Updating elasticsearch to version 7.x and updating configs to match

### DIFF
--- a/salt/standard-search.sls
+++ b/salt/standard-search.sls
@@ -2,12 +2,11 @@ include:
   - django
 
 elasticsearch:
-  cmd.run:
-    - name: wget -nv -O - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
   pkgrepo.managed:
     - humanname: Elasticsearch
-    - name: deb https://artifacts.elastic.co/packages/6.x/apt stable main
+    - name: deb https://artifacts.elastic.co/packages/7.x/apt stable main
     - file: /etc/apt/sources.list.d/elasticsearch.list
+    - key_url: https://packages.elasticsearch.org/GPG-KEY-elasticsearch
   pkg.installed:
     - pkgs:
       - apt-transport-https
@@ -26,7 +25,7 @@ elasticsearch:
 
 /etc/default/elasticsearch:
   file.managed:
-    - source: salt://etc-default/elasticsearch-standard-search
+    - source: salt://standard-search/elasticsearch-defaults
     - template: jinja
 
 /etc/elasticsearch/jvm.options:

--- a/salt/standard-search/elasticsearch-defaults
+++ b/salt/standard-search/elasticsearch-defaults
@@ -1,3 +1,7 @@
+#
+# THIS FILE IS MANAGED BY SALT - DO NOT EDIT MANUALLY
+#
+
 ################################
 # Elasticsearch
 ################################
@@ -62,7 +66,7 @@ ES_STARTUP_SLEEP_TIME=5
 # Specifies the maximum file descriptor number that can be opened by this process
 # When using Systemd, this setting is ignored and the LimitNOFILE defined in
 # /usr/lib/systemd/system/elasticsearch.service takes precedence
-#MAX_OPEN_FILES=65536
+#MAX_OPEN_FILES=65535
 
 # The maximum number of bytes of memory that may be locked into RAM
 # Set to "unlimited" if you use the 'bootstrap.memory_lock: true' option

--- a/salt/standard-search/jvm.options
+++ b/salt/standard-search/jvm.options
@@ -1,3 +1,7 @@
+#
+# THIS FILE IS MANAGED BY SALT - DO NOT EDIT MANUALLY
+#
+
 ## JVM configuration
 
 ################################################################
@@ -33,42 +37,21 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
-## optimizations
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
 
-# pre-touch memory pages used by the JVM during initialization
--XX:+AlwaysPreTouch
-
-## basic
-
-# explicitly set the stack size
--Xss1m
-
-# set to headless, just in case
--Djava.awt.headless=true
-
-# ensure UTF-8 encoding by default (e.g. filenames)
--Dfile.encoding=UTF-8
-
-# use our provided JNA always versus the system one
--Djna.nosys=true
-
-# turn off a JDK optimization that throws away stack traces for common
-# exceptions because stack traces are important for debugging
--XX:-OmitStackTraceInFastThrow
-
-# flags to configure Netty
--Dio.netty.noUnsafe=true
--Dio.netty.noKeySetOptimization=true
--Dio.netty.recycler.maxCapacityPerThread=0
-
-# log4j 2
--Dlog4j.shutdownHookEnabled=false
--Dlog4j2.disable.jmx=true
-
+## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}
 
 ## heap dumps
@@ -77,12 +60,14 @@
 # heap dumps are created in the working directory of the JVM
 -XX:+HeapDumpOnOutOfMemoryError
 
-# specify an alternative path for heap dumps
-# ensure the directory exists and has sufficient space
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
 -XX:HeapDumpPath=/var/lib/elasticsearch
 
-## JDK 8 GC logging
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
 
+## JDK 8 GC logging
 8:-XX:+PrintGCDetails
 8:-XX:+PrintGCDateStamps
 8:-XX:+PrintTenuringDistribution
@@ -94,6 +79,3 @@
 
 # JDK 9+ GC logging
 9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
-# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
-# time/date parsing will break in an incompatible way for some date patterns and locals
-9-:-Djava.locale.providers=COMPAT


### PR DESCRIPTION
ElasticSearch version 6.x goes end of life on the 20 Nov 2020. 

This pull request updates ES to version 7.x and updates the configs to match. 
I've also made a couple of improvements to how the apt key is stored and consolidating the custom configs together.

Below is the update process. These commands need to be ran in this order on standard-search (unless otherwise specified):

```
rm /etc/apt/sources.list.d/elasticsearch.list
# On your local system, salt-ssh state.apply
systemctl stop elasticsearch.service
apt-get update && apt-get dist-upgrade
# Yes accept defaults (two of them are overwritten by salt anyway)
# On your local system, salt-ssh state.apply
```

Finally we'll want to kick off a re-index of the docs, please can you advise here?
I can see the [deploy-docs.sh script](https://github.com/open-contracting/deploy/blob/master/deploy-docs.sh), is there any docs on how this is called?

We'll also need to update the [standard-search](https://github.com/open-contracting/standard-search) repo as the readme says ES version 6. 