### PR TITLE
Handing dev servers dynamically

### DIFF
--- a/pillar/common.sls
+++ b/pillar/common.sls
@@ -2,7 +2,7 @@
 
 prometheus:
   node_exporter:
-    enabled: true
+    enabled: false
 
 maintenance:
   enabled: false

--- a/pillar/prometheus_client.sls
+++ b/pillar/prometheus_client.sls
@@ -4,4 +4,5 @@ firewall:
 
 prometheus:
   node_exporter:
+    enabled: true
     version: 1.0.1

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -50,6 +50,6 @@ base:
     - maintenance
 
   # This avoids having to repeat these states for all but one target.
-  '* and not G@id:covid19-dev':
+  '* and not G@id:*-dev':
     - prometheus_client
     - private.prometheus_client

--- a/salt/core/firewall/files/firewall.sh
+++ b/salt/core/firewall/files/firewall.sh
@@ -13,6 +13,8 @@
 
 set -euo pipefail
 
+VERBOSE=true
+
 source /home/sysadmin-tools/firewall-settings.local
 
 function echo_verbose {

--- a/salt/core/firewall/files/firewall.sh
+++ b/salt/core/firewall/files/firewall.sh
@@ -13,8 +13,6 @@
 
 set -euo pipefail
 
-VERBOSE=true
-
 source /home/sysadmin-tools/firewall-settings.local
 
 function echo_verbose {


### PR DESCRIPTION
This PR makes a couple of small changes so that it is easier to create temporary dev servers in the future.
Specifically dev servers don't need anything installed for Prometheus.
`pillar/top.sls` was already doing this for `covid19-dev`, I've expanded this for `*-dev` because we will need this on future servers.
