### PR TITLE
git repo update script enhancement

### DIFF
--- a/script/update
+++ b/script/update
@@ -3,23 +3,27 @@
 
 set -xeuo pipefail
 
-git checkout master
-git pull --rebase origin master
+function main {
+	git checkout master
+	git pull --rebase origin master
 
-(
-  cd pillar/private
-  git checkout master
-  git pull --rebase origin master
-)
+	(
+	  cd pillar/private
+	  git checkout master
+	  git pull --rebase origin master
+	)
 
-(
-  cd salt/private
-  git checkout master
-  git pull --rebase origin master
-)
+	(
+	  cd salt/private
+	  git checkout master
+	  git pull --rebase origin master
+	)
 
-(
-  cd salt/maintenance
-  git checkout master
-  git pull --rebase origin master
-)
+	(
+	  cd salt/maintenance
+	  git checkout master
+	  git pull --rebase origin master
+	)
+}
+
+main


### PR DESCRIPTION
Small PR, this change makes sure that the update script is loaded into memory before executing.

Bash scripts by default execute each line as they go, this meant that if an update changed the update script it would run the git pull and update itself, then start executing the new script half way through.

This will be needed when we remove repos like "salt/private".