### PR TITLE
Allow access to postgres from appbeat IPs

### DIFF
--- a/salt/core/firewall/files/firewall.sh
+++ b/salt/core/firewall/files/firewall.sh
@@ -278,6 +278,8 @@ if [ "$PRIVATE_POSTGRESQL" == "yes" ]; then
     for IP in $LOCAL_IPV6 $REPLICA_IPV6; do
         $IP6TABLES -A INPUT -p tcp -s "$IP" --dport 5432 -j ACCEPT
     done
+    $IPTABLES -A INPUT -p tcp --dport 5432 -j monitor
+    $IP6TABLES -A INPUT -p tcp --dport 5432 -j monitor
 fi
 
 if [ "$PUBLIC_TINYPROXY" == "yes" ]; then

--- a/salt/postgres/files/pg_hba.conf
+++ b/salt/postgres/files/pg_hba.conf
@@ -30,3 +30,14 @@ hostssl replication     replica         {{ ip }}/32             md5
 hostssl replication     replica         {{ ip }}/128            md5
   {%- endfor %}
 {%- endif %}
+
+{% if salt['pillar.get']('maintenance:enabled') == True %}
+# Appbeat monitoring
+  {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv4').split() %}
+hostssl nodatabase      nouser         {{ ip }}/32             md5
+  {%- endfor %}
+
+  {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv6').split() %}
+hostssl nodatabase      nouser         {{ ip }}/128             md5
+  {%- endfor %}
+{%- endif %}

--- a/salt/postgres/files/pg_hba.conf
+++ b/salt/postgres/files/pg_hba.conf
@@ -21,23 +21,23 @@ hostssl	all		all		::/0			md5
 {%- if 'replica_ipv4' in pillar.postgres %}
 # Allow SSL connections from replicas (IPv4).
   {%- for ip in pillar.postgres.replica_ipv4 %}
-hostssl	replication	replica		{{ "{:18}".format(ip+"/32") }}	md5
+hostssl	replication	replica		{{ "{:18}".format(ip + "/32") }}	md5
   {%- endfor %}
 {%- endif %}
 {%- if 'replica_ipv6' in pillar.postgres %}
 # Allow SSL connections from replicas (IPv6).
   {%- for ip in pillar.postgres.replica_ipv6 %}
-hostssl	replication	replica		{{ "{:42}".format(ip+"/128") }}	md5
+hostssl	replication	replica		{{ "{:42}".format(ip + "/128") }}	md5
   {%- endfor %}
 {%- endif %}
 
 {%- if salt['pillar.get']('maintenance:enabled') %}
 # Appbeat monitoring
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv4').split() %}
-hostssl	nodatabase	nouser		{{ "{:18}".format(ip+"/32") }}	md5
+hostssl	nodatabase	nouser		{{ "{:18}".format(ip + "/32") }}	md5
   {%- endfor %}
 
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv6').split() %}
-hostssl	nodatabase	nouser		{{ "{:42}".format(ip+"/128") }}	md5
+hostssl	nodatabase	nouser		{{ "{:42}".format(ip + "/128") }}	md5
   {%- endfor %}
 {%- endif %}

--- a/salt/postgres/files/pg_hba.conf
+++ b/salt/postgres/files/pg_hba.conf
@@ -31,7 +31,7 @@ hostssl	replication	replica		{{ "{:42}".format(ip+"/128") }}	md5
   {%- endfor %}
 {%- endif %}
 
-{% if salt['pillar.get']('maintenance:enabled') == True %}
+{%- if salt['pillar.get']('maintenance:enabled') %}
 # Appbeat monitoring
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv4').split() %}
 hostssl	nodatabase	nouser		{{ "{:18}".format(ip+"/32") }}	md5

--- a/salt/postgres/files/pg_hba.conf
+++ b/salt/postgres/files/pg_hba.conf
@@ -1,43 +1,43 @@
-# TYPE  DATABASE        USER            ADDRESS                 METHOD
+# TYPE	DATABASE	USER		ADDRESS			METHOD
 # https://www.postgresql.org/docs/11/auth-pg-hba-conf.html
 
 # Local connections by postgres user. (Belts-and-suspenders approach.)
-local   all             postgres                                peer
+local	all		postgres				peer
 # Local connections for physical replication.
-local   replication     all                                     peer
-host    replication     all             127.0.0.1/32            md5
-host    replication     all             ::1/128                 md5
+local	replication	all					peer
+host	replication	all		127.0.0.1/32		md5
+host	replication	all		::1/128			md5
 # Local connections.
-local   all             all                                     peer
-host    all             all             127.0.0.1/32            md5
-host    all             all             ::1/128                 md5
+local	all		all					peer
+host	all		all		127.0.0.1/32		md5
+host	all		all		::1/128			md5
 
 {%- if pillar.postgres.get('public_access') %}
 # Remote connections with SSL encryption.
-hostssl all             all             0.0.0.0/0               md5
-hostssl all             all             ::/0                    md5
+hostssl	all		all		0.0.0.0/0		md5
+hostssl	all		all		::/0			md5
 {%- endif %}
 
 {%- if 'replica_ipv4' in pillar.postgres %}
 # Allow SSL connections from replicas (IPv4).
   {%- for ip in pillar.postgres.replica_ipv4 %}
-hostssl replication     replica         {{ ip }}/32             md5
+hostssl	replication	replica		{{ "%-18s" | format(ip+"/32",) }}	md5
   {%- endfor %}
 {%- endif %}
 {%- if 'replica_ipv6' in pillar.postgres %}
 # Allow SSL connections from replicas (IPv6).
   {%- for ip in pillar.postgres.replica_ipv6 %}
-hostssl replication     replica         {{ ip }}/128            md5
+hostssl	replication	replica		{{ "%-42s" | format(ip+"/128",) }}	md5
   {%- endfor %}
 {%- endif %}
 
 {% if salt['pillar.get']('maintenance:enabled') == True %}
 # Appbeat monitoring
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv4').split() %}
-hostssl nodatabase      nouser         {{ ip }}/32             md5
+hostssl	nodatabase	nouser		{{ "%-18s" | format(ip+"/32",) }}	md5
   {%- endfor %}
 
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv6').split() %}
-hostssl nodatabase      nouser         {{ ip }}/128             md5
+hostssl	nodatabase	nouser		{{ "%-42s" | format(ip+"/128",) }}	md5
   {%- endfor %}
 {%- endif %}

--- a/salt/postgres/files/pg_hba.conf
+++ b/salt/postgres/files/pg_hba.conf
@@ -21,23 +21,23 @@ hostssl	all		all		::/0			md5
 {%- if 'replica_ipv4' in pillar.postgres %}
 # Allow SSL connections from replicas (IPv4).
   {%- for ip in pillar.postgres.replica_ipv4 %}
-hostssl	replication	replica		{{ "%-18s" | format(ip+"/32",) }}	md5
+hostssl	replication	replica		{{ "{:18}".format(ip+"/32") }}	md5
   {%- endfor %}
 {%- endif %}
 {%- if 'replica_ipv6' in pillar.postgres %}
 # Allow SSL connections from replicas (IPv6).
   {%- for ip in pillar.postgres.replica_ipv6 %}
-hostssl	replication	replica		{{ "%-42s" | format(ip+"/128",) }}	md5
+hostssl	replication	replica		{{ "{:42}".format(ip+"/128") }}	md5
   {%- endfor %}
 {%- endif %}
 
 {% if salt['pillar.get']('maintenance:enabled') == True %}
 # Appbeat monitoring
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv4').split() %}
-hostssl	nodatabase	nouser		{{ "%-18s" | format(ip+"/32",) }}	md5
+hostssl	nodatabase	nouser		{{ "{:18}".format(ip+"/32") }}	md5
   {%- endfor %}
 
   {%- for ip in salt.cmd.run('curl -sS https://www.appbeat.io/probes/ipv6').split() %}
-hostssl	nodatabase	nouser		{{ "%-42s" | format(ip+"/128",) }}	md5
+hostssl	nodatabase	nouser		{{ "{:42}".format(ip+"/128") }}	md5
   {%- endfor %}
 {%- endif %}

--- a/salt/postgres/init.sls
+++ b/salt/postgres/init.sls
@@ -16,6 +16,9 @@
   {% if pillar.postgres.get('replica_ipv6') %}
     {{ set_firewall("REPLICA_IPV6", pillar.postgres.replica_ipv6|join(' ')) }}
   {% endif %}
+  {% if salt['pillar.get']('maintenance.enabled', True) %}
+    {{ set_firewall("MONITOR_APPBEAT") }}
+  {% endif %}
 {% endif %}
 
 postgresql:

--- a/salt/postgres/init.sls
+++ b/salt/postgres/init.sls
@@ -16,7 +16,7 @@
   {% if pillar.postgres.get('replica_ipv6') %}
     {{ set_firewall("REPLICA_IPV6", pillar.postgres.replica_ipv6|join(' ')) }}
   {% endif %}
-  {% if salt['pillar.get']('maintenance.enabled', True) %}
+  {% if salt['pillar.get']('maintenance:enabled') %}
     {{ set_firewall("MONITOR_APPBEAT") }}
   {% endif %}
 {% endif %}

--- a/salt/postgres/init.sls
+++ b/salt/postgres/init.sls
@@ -30,7 +30,8 @@ postgresql:
     - require:
       - pkgrepo: postgresql
   service.running:
-    - name: postgresql
+    # The service called "postgresql" is a dummy service for this
+    - name: postgresql@{{ pg_version }}-main.service
     - enable: True
     - require:
       - pkg: postgresql
@@ -38,7 +39,7 @@ postgresql:
 postgresql-reload:
   module.wait:
     - name: service.reload
-    - m_name: postgresql
+    - m_name: postgresql@{{ pg_version }}-main.service
 
 # Upload access configuration for postgres.
 /etc/postgresql/{{ pg_version }}/main/pg_hba.conf:


### PR DESCRIPTION
Enables AppBeat monitoring, closes #205 
Also fixes Postgres not identifying if the service is broken after a service restart, closes #166 