### PR TITLE
258-move-ver-txt-in-covid-salt

### DIFF
--- a/salt/covid19.sls
+++ b/salt/covid19.sls
@@ -45,7 +45,7 @@ pkill celery:
 
 {{static_dir}}/ver.txt:
   file.managed:
-    - contents: "branch: {{ backend_entry.git.branch }} || commit_hash: {{ salt['cmd.shell']('cd ' + directory + '&& git rev-parse --verify HEAD') }} || time: {{ timestamp }}"
+    - contents: "branch: {{ backend_entry.git.branch }} || commit_hash: {{ salt['cmd.shell']('cd ' + directory + '&& git rev-parse --verify '+ backend_entry.git.branch ) }} || time: {{ timestamp }}"
   {% endif %}
 
 {% endif %}

--- a/salt/react_apps/init.sls
+++ b/salt/react_apps/init.sls
@@ -9,7 +9,7 @@ include:
 {% set userdir = '/home/' + entry.user %}
 {% set directory = userdir + '/' + entry.git.target %}
 {% set builddir = userdir + '/releases' %}
-{% set timestamp = salt['cmd.run']('date +%Y%m%d%H%M%S') %}
+{% set timestamp = salt['cmd.run']('date +%Y-%m-%d_%H:%M:%S') %}
 {% set appdir = userdir + '/current' %}
 {% set context = {'name': name, 'entry': entry, 'appdir': appdir} %}
 
@@ -86,7 +86,7 @@ include:
 {{ builddir }}/{{ timestamp }}/ver.txt:
   file.managed:
     - contents: |
-        {{ entry.git.branch }} {{ salt['cmd.shell']('cd ' + directory + ' && git rev-parse --verify HEAD') }} {{ salt['cmd.run']('date +%Y-%m-%d_%H:%M:%S') }}
+        {{ entry.git.branch }} {{ salt['cmd.shell']('cd ' + directory + ' && git rev-parse --verify ' + entry.git.branch ) }} {{ salt['cmd.run']('date +%Y-%m-%d_%H:%M:%S') }}
     - user: {{ entry.user }}
     - group: {{ entry.user }}
     - require:


### PR DESCRIPTION
* [x] moved deployment tracking ver.txt salt function to covid19 salt file

closes #258