### PR TITLE
Enabling regular postgres backups

### DIFF
--- a/pillar/kingfisher.sls
+++ b/pillar/kingfisher.sls
@@ -108,4 +108,10 @@ postgres:
     - 2a01:4f8:211:de::2
   backup:
     configuration: kingfisher-process1
-    # cron_enabled: True # Disabled to test backup timing
+    process_max: 8
+    cron: |
+        MAILTO=root
+        # Daily incremental backup
+        15 05 * * 0-2,4-6 postgres pgbackrest backup --stanza=kingfisher
+        # Weekly full backup
+        15 05 * * 3 postgres pgbackrest backup --stanza=kingfisher --type=full

--- a/pillar/kingfisher_common.sls
+++ b/pillar/kingfisher_common.sls
@@ -2,7 +2,6 @@ postgres:
   backup:
     stanza: kingfisher
     retention_full: 4
-    process_max: 4
     s3_bucket: ocp-db-backup
     s3_endpoint: s3.eu-central-1.amazonaws.com
     s3_region: eu-central-1

--- a/pillar/kingfisher_replica.sls
+++ b/pillar/kingfisher_replica.sls
@@ -11,6 +11,7 @@ postgres:
   configuration: kingfisher-replica1
   backup:
     configuration: kingfisher-replica1
+    process_max: 6
   replication:
     primary_slot_name: replica1
 

--- a/salt/postgres/backup.sls
+++ b/salt/postgres/backup.sls
@@ -16,17 +16,12 @@ pgbackrest:
    - source: salt://postgres/files/pgbackrest/{{ pillar.postgres.backup.configuration }}.conf
    - template: jinja
 
-{%- if salt['pillar.get']('postgres:backup:cron_enabled') %}
+{%- if salt['pillar.get']('postgres:backup:cron') %}
 # Using file.append rather than the salt cron module.
 # Because system crons are easier to find if they are all stored in /etc.
 /etc/cron.d/postgres_backups:
-  file.append:
-    - text: |
-        MAILTO=root
-        # Daily incremental backup
-        15 05 * * 1-6 postgres pgbackrest backup
-        # Weekly full backup
-        15 05 * * 7 postgres pgbackrest backup --type=full
+  file.managed:
+    - contents_pillar: postgres:backup:cron
     - require:
       - pkg: pgbackrest
 {%- endif %}


### PR DESCRIPTION
I manually ran a pgBackRest Postgres backup this morning it took roughly 2 hours 15 minutes to complete and compressed the backup size down to only 500GB. 
I am very happy with both of these stats :smile: 

Based on this information, I expect AWS S3 to cost roughly $50 - $60 per month.
We can potentially reduce this cost by moving to S3 infrequent access or possibly Glacier.
I don't have good visibility on the number of requests the backup process made which may change this recommendation.

Salt is currently configured to keep the last four full backups (`retention_full`).

This PR enables daily incremental backups with a weekly full backup (running on Wednesday morning).