### PR TITLE
Configuring journald in salt

### DIFF
--- a/salt/core/journald.sls
+++ b/salt/core/journald.sls
@@ -1,0 +1,13 @@
+/etc/systemd/journald.conf.d/customization.conf:
+  file.managed:
+    - contents: | 
+        [Journal]
+        SystemMaxUse=1024M
+    - user: root
+    - group: root
+    - mkdirs: true
+    - watch_in:
+      - service: systemd-journald
+
+systemd-journald:
+  service.running

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -7,6 +7,7 @@ base:
     - core.customization
     - core.fail2ban
     - core.firewall
+    - core.journald
     - core.locale
     - core.logrotate
     - core.mail


### PR DESCRIPTION
Setting journald log storage limits as we've seen disk space issues on the live.docs server.