### PR TITLE
Limit temp tables to 1TB

### DIFF
--- a/salt/postgres/files/conf/kingfisher-replica1.conf
+++ b/salt/postgres/files/conf/kingfisher-replica1.conf
@@ -55,6 +55,12 @@ max_parallel_workers_per_gather = {{ grains.num_cpus // 2 }}
 # https://github.com/le0pard/pgtune/blob/a002a699e77426d5c5221645df999eec7fe92472/webpack/selectors/configuration.js#L306
 max_parallel_maintenance_workers = {{ [4, grains.num_cpus // 2] | min }}
 
+### Storage
+
+# https://www.postgresql.org/docs/13/runtime-config-resource.html#GUC-TEMP-FILE-LIMIT
+# https://github.com/open-contracting/deploy/issues/272
+temp_file_limit = 1TB
+
 ##################
 # Query Planning #
 ##################


### PR DESCRIPTION
@jpmckinney small PR setting 1TB limit on Postgres temp file.
This only sets the variable on the replica1 server, would we like this set on kingfisher-process1?