### PR TITLE
Removing main. alias prefix

### DIFF
--- a/pillar/cove.sls
+++ b/pillar/cove.sls
@@ -15,7 +15,6 @@ python_apps:
         VALIDATION_ERROR_LOCATIONS_LENGTH: 100
     apache:
       configuration: django
-      serveraliases: ['{{ grains.fqdn }}'] # should match python.cove.git.branch
       context:
         docs_ipv4: 5.28.62.151
         docs_ipv6: 2001:41c9:1:41c::151

--- a/pillar/cove.sls
+++ b/pillar/cove.sls
@@ -15,7 +15,7 @@ python_apps:
         VALIDATION_ERROR_LOCATIONS_LENGTH: 100
     apache:
       configuration: django
-      serveraliases: ['main.{{ grains.fqdn }}'] # should match python.cove.git.branch
+      serveraliases: ['{{ grains.fqdn }}'] # should match python.cove.git.branch
       context:
         docs_ipv4: 5.28.62.151
         docs_ipv6: 2001:41c9:1:41c::151


### PR DESCRIPTION
@jpmckinney I've identified a bug in the cove Apache configuration that is breaking SSL renewal.

Currently `serveraliases` is set to `main.{{grains.fqdn}}` which worked fine for the old hostname `main.cove-live.oc4ids.opencontracting.uk0.bigv.io` but this doesn't work with the new one because `main.ocp01.open-contracting.org` doesn't have any DNS records.

This PR removes the `main.` prefix which works around this, however I am unsure why it was configured this way in the first place?