### PR TITLE
fix: docker_apps check for target

### DIFF
--- a/salt/docker_apps/init.sls
+++ b/salt/docker_apps/init.sls
@@ -2,7 +2,7 @@ include:
   - docker
 
 {% for name, entry in pillar.docker_apps.items() %}
-{% if entry.target %}
+{% if 'target' in entry %}
 
 {% set directory = '/data/deploy/' + entry.target %}
 
@@ -16,7 +16,7 @@ include:
     - require:
       - user: {{ pillar.docker.user }}_user_exists
 
-{% if entry.env %}
+{% if 'env' in entry %}
 {{ directory }}/env:
   file.managed:
     - source: salt://docker_apps/files/env


### PR DESCRIPTION
Otherwise a "`Jinja variable 'salt.utils.odict.OrderedDict object' has no attribute 'target'`" error is raised