### PR TITLE
Prometheus alert rules

### DIFF
--- a/salt/prometheus/files/conf-prometheus-rules.yml
+++ b/salt/prometheus/files/conf-prometheus-rules.yml
@@ -4,39 +4,30 @@ groups:
     rules:
       - alert: InstanceDown
         expr: up == 0
-        for: 3m
+        for: 20m
         labels:
           severity: critical
         annotations:
           summary: "Endpoint {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} is down."
 
-      - alert: AvailableMemoryLow20PerCent
-        expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.2
-        for: 3m
+      - alert: AvailableMemoryLow90PerCent
+        expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1
+        for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "Endpoint {{ $labels.instance }} has less than 20% available memory"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 20% available memory."
-
-      - alert: AvailableMemoryLow5PerCent
-        expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.05
-        for: 3m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{ $labels.instance }} has less than 5% available memory"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 5% available memory."
+          summary: "Endpoint {{ $labels.instance }} has less than 10% available memory"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 10% available memory."
 
       - alert: RootFileSystemLow
-        expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.05
-        for: 3m
+        expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.15
+        for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "Endpoint {{ $labels.instance }} has less than 5% of disk space"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 5% of disk space."
+          summary: "Endpoint {{ $labels.instance }} has less than 15% of disk space"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 15% of disk space."
 
       - alert: SmartMonDeviceIsUnhealthy
         expr: smartmon_device_smart_healthy != 1
@@ -69,7 +60,7 @@ groups:
           description: "{{ $labels.instance }} of job {{ $labels.job }} is reporting it does not have data for Smartmon"
 
       - alert: DiskIOHigh20Percent
-        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job!~"ocds-kingfisher.*"}[10m]))) * 100 >= 20
+        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job!~"ocds-kingfisher.*|data-registry"}[10m]))) * 100 >= 20
         for: 4h
         labels:
           severity: critical
@@ -86,21 +77,30 @@ groups:
           summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
 
+      - alert: DiskIOHigh20PercentRegistry
+        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job=~"data-registry"}[10m]))) * 100 >= 20
+        for: 12h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
+
       - alert: LowDiskSpace10Percent
         expr:
           node_filesystem_avail_bytes{fstype!~"rootfs|selinuxfs|autofs|rpc_pipefs|tmpfs|aufs|proc", mountpoint!~".*(/aufs|docker).*"}
           / node_filesystem_size_bytes{fstype!~"rootfs|selinuxfs|autofs|rpc_pipefs|tmpfs|aufs|proc", mountpoint!~".*(/aufs|docker).*"}
-          * 100 <= 10
-        for: 3m
+          * 100 <= 15
+        for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "Endpoint {{$labels.instance}} has less than 10% of disk space"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 10% of disk space."
+          summary: "Endpoint {{$labels.instance}} has less than 15% of disk space"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 15% of disk space."
 
       - alert: CPUHigh80Percent
         expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job!="covid19"}[5m])) * 100) >= 80
-        for: 3m
+        for: 15m
         labels:
           severity: critical
         annotations:

--- a/salt/prometheus/files/conf-prometheus-rules.yml
+++ b/salt/prometheus/files/conf-prometheus-rules.yml
@@ -3,7 +3,7 @@ groups:
   - name: alert.rules
     rules:
 
-      ## Deadman switch
+      ## Availability
 
       - alert: InstanceDown
         expr: up == 0
@@ -83,7 +83,7 @@ groups:
           summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
 
-      ## Disk Space
+      ## Disk space
 
       - alert: RootFileSystemLow
         expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.15

--- a/salt/prometheus/files/conf-prometheus-rules.yml
+++ b/salt/prometheus/files/conf-prometheus-rules.yml
@@ -2,6 +2,9 @@
 groups:
   - name: alert.rules
     rules:
+
+      ## Deadman switch
+
       - alert: InstanceDown
         expr: up == 0
         for: 20m
@@ -10,6 +13,28 @@ groups:
         annotations:
           summary: "Endpoint {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} is down."
+
+      ## CPU
+
+      - alert: CPUHigh80Percent
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job!="covid19"}[5m])) * 100) >= 80
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} has greater than 80% CPU usage"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 80% CPU usage."
+
+      - alert: CPUHigh80PercentCovid19
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job="covid19"}[5m])) * 100) >= 80
+        for: 4h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} has greater than 80% CPU usage"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 80% CPU usage."
+
+      ## Memory 
 
       - alert: AvailableMemoryLow90PerCent
         expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1
@@ -20,6 +45,37 @@ groups:
           summary: "Endpoint {{ $labels.instance }} has less than 10% available memory"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 10% available memory."
 
+      ## Disk IO
+
+      - alert: DiskIOHigh20Percent
+        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job!~"ocds-kingfisher.*|data-registry"}[10m]))) * 100 >= 20
+        for: 4h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
+
+      - alert: DiskIOHigh20PercentKingfisher
+        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job=~"ocds-kingfisher.*"}[10m]))) * 100 >= 20
+        for: 12h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
+
+      - alert: DiskIOHigh20PercentRegistry
+        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job=~"data-registry"}[10m]))) * 100 >= 20
+        for: 12h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
+
+      ## Disk Space
+
       - alert: RootFileSystemLow
         expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.15
         for: 5m
@@ -28,6 +84,22 @@ groups:
         annotations:
           summary: "Endpoint {{ $labels.instance }} has less than 15% of disk space"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 15% of disk space."
+
+      - alert: LowDiskSpace15Percent
+        expr:
+          node_filesystem_avail_bytes{fstype!~"rootfs|selinuxfs|autofs|rpc_pipefs|tmpfs|aufs|proc", mountpoint!~".*(/aufs|docker).*"}
+          / node_filesystem_size_bytes{fstype!~"rootfs|selinuxfs|autofs|rpc_pipefs|tmpfs|aufs|proc", mountpoint!~".*(/aufs|docker).*"}
+          * 100 <= 15
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{$labels.instance}} has less than 15% of disk space"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 15% of disk space."
+
+      ## Hardware server, Disk SMART monitoring
+
+      # Alerting when raw value > 0 https://www.backblaze.com/blog/hard-drive-smart-stats/
 
       - alert: SmartMonDeviceIsUnhealthy
         expr: smartmon_device_smart_healthy != 1
@@ -59,64 +131,6 @@ groups:
           summary: "Endpoint {{ $labels.instance }} does not have data for Smartmon"
           description: "{{ $labels.instance }} of job {{ $labels.job }} is reporting it does not have data for Smartmon"
 
-      - alert: DiskIOHigh20Percent
-        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job!~"ocds-kingfisher.*|data-registry"}[10m]))) * 100 >= 20
-        for: 4h
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
-
-      - alert: DiskIOHigh20PercentKingfisher
-        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job=~"ocds-kingfisher.*"}[10m]))) * 100 >= 20
-        for: 12h
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
-
-      - alert: DiskIOHigh20PercentRegistry
-        expr: (avg by(instance, device) (rate(node_disk_io_time_seconds_total{job=~"data-registry"}[10m]))) * 100 >= 20
-        for: 12h
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{$labels.instance}} has greater than 20% disk utilisation on {{ $labels.device }}"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 20% disk utilisation on {{ $labels.device }}."
-
-      - alert: LowDiskSpace10Percent
-        expr:
-          node_filesystem_avail_bytes{fstype!~"rootfs|selinuxfs|autofs|rpc_pipefs|tmpfs|aufs|proc", mountpoint!~".*(/aufs|docker).*"}
-          / node_filesystem_size_bytes{fstype!~"rootfs|selinuxfs|autofs|rpc_pipefs|tmpfs|aufs|proc", mountpoint!~".*(/aufs|docker).*"}
-          * 100 <= 15
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{$labels.instance}} has less than 15% of disk space"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has less than 15% of disk space."
-
-      - alert: CPUHigh80Percent
-        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job!="covid19"}[5m])) * 100) >= 80
-        for: 15m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{ $labels.instance }} has greater than 80% CPU usage"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 80% CPU usage."
-
-      - alert: CPUHigh80PercentCovid19
-        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job="covid19"}[5m])) * 100) >= 80
-        for: 4h
-        labels:
-          severity: critical
-        annotations:
-          summary: "Endpoint {{ $labels.instance }} has greater than 80% CPU usage"
-          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 80% CPU usage."
-
-      # Alerting when raw value > 0 https://www.backblaze.com/blog/hard-drive-smart-stats/
       - alert: SmartReallocatedSectorCount
         expr: smartmon_reallocated_sector_ct_raw_value > 0
         for: 3m

--- a/salt/prometheus/files/conf-prometheus-rules.yml
+++ b/salt/prometheus/files/conf-prometheus-rules.yml
@@ -17,7 +17,7 @@ groups:
       ## CPU
 
       - alert: CPUHigh80Percent
-        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job!="covid19"}[5m])) * 100) >= 80
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job!="covid19|data-registry"}[5m])) * 100) >= 80
         for: 15m
         labels:
           severity: critical
@@ -27,6 +27,15 @@ groups:
 
       - alert: CPUHigh80PercentCovid19
         expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job="covid19"}[5m])) * 100) >= 80
+        for: 4h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} has greater than 80% CPU usage"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has greater than 80% CPU usage."
+
+      - alert: CPUHigh80PercentRegistry
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle", job="data-registry"}[5m])) * 100) >= 80
         for: 4h
         labels:
           severity: critical


### PR DESCRIPTION
This PR increases the alert thresholds for ocp13 / registry to better match the server usage.

While I was in here I took this opportunity to update prometheus monitoring for our internal monitoring standards, including:
* Increasing InstanceDown alert time (we have dedicated uptime monitoring which is more reliable for this)
* Increased Memory alert threshold and removed double alert
* Reduced File System threshold to 85% (some systems will have 5% disk space reserved for only root)
* Tweaking alert timers to further reduce false positives.
* Restructuring the rules file to have alert categories next to each other.

@jpmckinney I haven't deployed any changes to our Prometheus stack before. Are there any other commands that need running to load in these new rules? I couldn't see anything in the docs so I am assuming not.