### PR TITLE
Cove servers /tmp management

### DIFF
--- a/salt/cove.sls
+++ b/salt/cove.sls
@@ -28,3 +28,8 @@ set MAILTO environment variable in {{ entry.user }} crontab:
     - user: {{ entry.user }}
     - require:
       - user: {{ entry.user }}_user_exists
+
+# By default this clears down /tmp data older than 7 days.
+clean up tmp data when python errors:
+  pkg.installed:
+    - name: tmpreaper


### PR DESCRIPTION
Checking now no further "uploads" files have been created on OCP02 so I presume the app is managing tmp files and closing them correctly. 
This PR addresses when the cove app errors and leaves uploads behind helping protect against disk space running out. 

Closes #359