### PR TITLE
Registry netplan configuration

### DIFF
--- a/docs/develop/update/network.rst
+++ b/docs/develop/update/network.rst
@@ -50,7 +50,7 @@ Update the server's Pillar file:
      ipv4: 198.51.100.34
      ipv6: 2001:db8::12
      netplan:
-       configuration: linode
+       template: linode
        addresses:
          - 2001:db8::32/64    # SLAAC
        gateway4: 198.51.100.1
@@ -76,7 +76,7 @@ Other hosting providers
 
    This step is optional. Only override a Netplan configuration if necessary. For example, Hetzner's `installimage <https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage/>` script creates a `configuration file <https://github.com/hetzneronline/installimage/blob/84883efa372b9c9ecef2bb7703d696221b4e1093/network_config.functions.sh#L560>`__.
 
-In the server's Pillar file, set ``network.netplan.configuration`` to ``custom`` and set ``network.netplan.ethernets``:
+In the server's Pillar file, set ``network.netplan.template`` to ``custom`` and set ``network.netplan.configuration``:
 
 .. code-block:: yaml
 
@@ -85,7 +85,13 @@ In the server's Pillar file, set ``network.netplan.configuration`` to ``custom``
      ipv4: 198.51.100.34
      ipv6: 2001:db8::12
      netplan:
-       configuration: custom
-       ethernets:
-         eth0:
-            # Your Netplan configuration for the eth0 device.
+       template: custom
+       configuration: |
+         network:
+           version: 2
+           renderer: networkd
+           ethernets:
+             eth0:
+               addresses:
+                 - 198.51.100.34/32
+                 ...

--- a/docs/develop/update/network.rst
+++ b/docs/develop/update/network.rst
@@ -74,7 +74,7 @@ Other hosting providers
 
 .. note::
 
-   This step is optional. Only override a Netplan configuration if necessary. For example, Hetzner's `installimage <https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage/>` script creates a `configuration file <https://github.com/hetzneronline/installimage/blob/84883efa372b9c9ecef2bb7703d696221b4e1093/network_config.functions.sh#L560>`__.
+   This step is optional. Only override a Netplan configuration if necessary. For example, Hetzner's `installimage <https://docs.hetzner.com/robot/dedicated-server/operating-systems/installimage/>`__ script creates a `configuration file <https://github.com/hetzneronline/installimage/blob/84883efa372b9c9ecef2bb7703d696221b4e1093/network_config.functions.sh#L560>`__.
 
 In the server's Pillar file, set ``network.netplan.template`` to ``custom`` and set ``network.netplan.configuration``:
 

--- a/pillar/redash.sls
+++ b/pillar/redash.sls
@@ -3,7 +3,7 @@ network:
   ipv4: 139.162.199.85
   ipv6: 2a01:7e00:e000:02cc::14
   netplan:
-    configuration: linode
+    template: linode
     addresses:
       - 2a01:7e00::f03c:92ff:fea5:0e5f/64    # SLAAC
     gateway4: 139.162.199.1

--- a/pillar/registry.sls
+++ b/pillar/registry.sls
@@ -1,3 +1,33 @@
+network:
+  host_id: ocp13
+  ipv4: 65.21.93.181
+  ipv6: 2a01:4f9:3b:45ca::2
+  netplan:
+    template: custom
+    configuration: |
+      network:
+        version: 2
+        renderer: networkd
+        ethernets:
+          enp9s0:
+            addresses:
+              - 65.21.93.181/32
+              - 65.21.93.141/32
+              - 2a01:4f9:3b:45ca::2/64
+            routes:
+              - on-link: true
+                to: 0.0.0.0/0
+                via: 65.21.93.129
+            gateway6: fe80::1
+            nameservers:
+              addresses:
+                - 213.133.99.99
+                - 213.133.100.100
+                - 213.133.98.98
+                - 2a01:4f8:0:1::add:9898
+                - 2a01:4f8:0:1::add:9999
+                - 2a01:4f8:0:1::add:1010
+
 vm:
   nr_hugepages: 8231
 

--- a/salt/core/network/files/netplan_custom.yaml
+++ b/salt/core/network/files/netplan_custom.yaml
@@ -1,4 +1,1 @@
-network:
-  version: 2
-  renderer: networkd
-  ethernets: {{ pillar.network.netplan.ethernets }}
+{{ pillar.network.netplan.configuration }}

--- a/salt/core/network/init.sls
+++ b/salt/core/network/init.sls
@@ -44,7 +44,7 @@ set hostname:
 
 /etc/netplan/10-salt-networking.yaml:
   file.managed:
-    - source: salt://core/network/files/netplan_{{ pillar.network.netplan.configuration }}.yaml
+    - source: salt://core/network/files/netplan_{{ pillar.network.netplan.template }}.yaml
     - template: jinja
 
 netplan_apply:


### PR DESCRIPTION
Improving the Netplan configuration for "custom" set ups and adding the Registry server netplan configs into salt 
This closes #278

When we deploy this it will remove the old hostname - `amy01`- from the server configs. Nothing should be using this any more so we are OK to remove it.