### PR TITLE
Apache to wait for networking

### DIFF
--- a/pillar/registry.sls
+++ b/pillar/registry.sls
@@ -39,6 +39,7 @@ apache:
   public_access: True
   ipv4: 65.21.93.181
   ipv6: 2a01:4f9:3b:45ca::2
+  wait_for_networking: True
   sites:
     # Can use Scrapyd's basic authentication instead once 1.3 is released.
     # https://github.com/scrapy/scrapyd/issues/364

--- a/salt/apache/init.sls
+++ b/salt/apache/init.sls
@@ -57,3 +57,15 @@ apache2-utils:
 {{ apache(name, entry) }}
 {% endfor %}
 {% endif %}
+
+# Delay the Apache start up if the server has multiple IP addresses.
+{% if salt['pillar.get']('apache:wait_for_networking') == True %}
+/etc/systemd/system/apache2.service.d/customization.conf:
+  file.managed:
+    - source: salt://core/systemd/files/apache2.conf
+    - makedirs: True
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/apache2.service.d/customization.conf
+{% endif %}

--- a/salt/apache/init.sls
+++ b/salt/apache/init.sls
@@ -58,8 +58,8 @@ apache2-utils:
 {% endfor %}
 {% endif %}
 
+{% if salt['pillar.get']('apache:wait_for_networking') %}
 # Delay the Apache start up if the server has multiple IP addresses.
-{% if salt['pillar.get']('apache:wait_for_networking') == True %}
 /etc/systemd/system/apache2.service.d/customization.conf:
   file.managed:
     - source: salt://core/systemd/files/apache2.conf

--- a/salt/core/systemd/files/apache2.conf
+++ b/salt/core/systemd/files/apache2.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=network-online.target


### PR DESCRIPTION
Fixes #286

I didn't use the `systemd` macro because it seemed a bit overkill for what I needed. This approach uploads `/etc/systemd/system/apache2.service.d/customization.conf` which modifies the existing apache2 systemd config file rather than overwriting it.