### PR TITLE
Docs Ubuntu Upgrade

### DIFF
--- a/docs/deploy/create_server.rst
+++ b/docs/deploy/create_server.rst
@@ -288,7 +288,6 @@ For Django application servers:
 For OCDS documentation servers:
 
 #. Copy the ``/home/ocds-docs/web`` directory
-#. Update the IP addresses in the ``pillar/cove.sls`` file, and deploy the ``cove-*`` services
 
 For Redmine servers:
 

--- a/pillar/cove.sls
+++ b/pillar/cove.sls
@@ -15,9 +15,6 @@ python_apps:
         VALIDATION_ERROR_LOCATIONS_LENGTH: 100
     apache:
       configuration: django
-      context:
-        docs_ipv4: 5.28.62.151
-        docs_ipv6: 2001:41c9:1:41c::151
     uwsgi:
       configuration: django
       harakiri: 1800 # 30 min

--- a/pillar/docs.sls
+++ b/pillar/docs.sls
@@ -1,3 +1,11 @@
+network:
+  host_id: ocp19
+  ipv4: 178.79.135.174
+  #ipv6: 2001:db8::19
+  networkd:
+    template: linode
+    gateway4: 178.79.135.1
+
 ssh:
   docs:
     # Public key for salt/private/keys/docs_ci

--- a/salt-config/roster
+++ b/salt-config/roster
@@ -16,6 +16,7 @@ registry:
 # ocp01 was cove-oc4ids on Ubuntu 18
 # ocp02 was cove-ocds on Ubuntu 18
 # ocp06 was covid19-dev
+# ocp07 was docs on Ubuntu 18
 # ocp08 was redash.open-contracting.org on Ubuntu 18
 # ocp09 was toucan.open-contracting.org
 # ocp10 was archive.kingfisher.open-contracting.org

--- a/salt-config/roster
+++ b/salt-config/roster
@@ -2,7 +2,7 @@
 
 cove-oc4ids:         ocp17.open-contracting.org
 cove-ocds:           ocp18.open-contracting.org
-docs:                ocp07.open-contracting.org
+docs:                ocp19.open-contracting.org
 kingfisher-process:  ocp04.open-contracting.org
 kingfisher-replica:  ocp05.open-contracting.org
 prometheus:          ocp03.open-contracting.org

--- a/salt/apache/files/sites/docs.conf.include
+++ b/salt/apache/files/sites/docs.conf.include
@@ -76,8 +76,6 @@ SetEnv BANNER /includes/banner_live.html
     SetEnv BANNER /includes/banner_staging_profiles_ppp.html
 </Location>
 
-# Needed to proxy to SSL servers.
-SSLProxyEngine on
 # ProxyPreserveHost was on but we need it to be Off, as it makes adding SSL much easier.
 ProxyPreserveHost Off
 # With a keepalive, we had problems with headers being interpreted as the start of the response.
@@ -347,3 +345,9 @@ RedirectMatch ^/infrastructure/review/(.*)$ https://review-oc4ids.standard.open-
     # The backreferences are the root, version and language.
     RewriteRule ^{{ documentroot }}/staging/{{ pattern }}([^/]*) https://standard.open-contracting.org/staging/$1$2/${unescape:%1}/? [R]
 </LocationMatch>
+
+####################
+# ElasticSearch
+####################
+ProxyPass "/ocdsindex_en" "http://localhost:9200/"
+ProxyPassReverse "/ocdsindex_en" "http://localhost:9200/"

--- a/salt/apache/includes/cove.include.jinja
+++ b/salt/apache/includes/cove.include.jinja
@@ -1,6 +1,1 @@
 ErrorDocument 500 "<h2>Sorry, something went wrong.</h2> <p>Sometimes this happens because the input file is too big - maybe try again with a smaller sample.</p><p>Please file a <a href=\"https://github.com/open-contracting/cove-ocds/issues/new\">GitHub issue</a> or email <a href=\"mailto:data@open-contracting.org\">data@open-contracting.org</a> if this problem persists.</p>"
-
-RemoteIPHeader X-Forwarded-For
-# Trust docs reverse proxy.
-RemoteIPTrustedProxy {{ docs_ipv4 }}
-RemoteIPTrustedProxy {{ docs_ipv6 }}

--- a/salt/docs/init.sls
+++ b/salt/docs/init.sls
@@ -6,7 +6,15 @@ include:
   - apache.modules.rewrite
 
 {% set user = 'ocds-docs' %}
+{% set userdir = '/home/' + user %}
 {{ create_user(user, authorized_keys=pillar.ssh.docs) }}
+
+allow {{ userdir }} access:
+  file.directory:
+    - name: {{ userdir }}
+    - mode: 755
+    - require:
+      - user: {{ user }}_user_exists
 
 # Needed to create a ZIP file of the schema and codelists.
 # https://ocdsdeploy.readthedocs.io/en/latest/deploy/docs.html#copy-the-schema-and-zip-file-into-place

--- a/salt/elasticsearch/files/config/readonlyrest-docs.yml
+++ b/salt/elasticsearch/files/config/readonlyrest-docs.yml
@@ -1,9 +1,6 @@
 readonlyrest:
   # https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#loading-settings-order-of-precedence
   force_load_from_file: True
-  ssl:
-    server_certificate_key_file: {{ pillar.elasticsearch.plugins.readonlyrest.certificate_key_file }}
-    server_certificate_file: {{ pillar.elasticsearch.plugins.readonlyrest.certificate_file }}
   # https://github.com/beshu-tech/readonlyrest-docs/blob/master/actionstrings/action_strings_es7.10.1.txt
   access_control_rules:
     - name: Allow localhost

--- a/salt/elasticsearch/files/restart-elasticsearch.sh
+++ b/salt/elasticsearch/files/restart-elasticsearch.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sudo /bin/systemctl restart elasticsearch.service

--- a/salt/elasticsearch/files/sudoers.d/restart-elasticsearch
+++ b/salt/elasticsearch/files/sudoers.d/restart-elasticsearch
@@ -1,1 +1,0 @@
-www-data    ALL=(root) NOPASSWD: /bin/systemctl restart elasticsearch.service

--- a/salt/elasticsearch/plugins/readonlyrest.sls
+++ b/salt/elasticsearch/plugins/readonlyrest.sls
@@ -12,24 +12,6 @@ readonlyrest-install:
     - watch_in:
       - service: elasticsearch
 
-/opt/restart-elasticsearch.sh:
-  file.managed:
-    - name: /opt/restart-elasticsearch.sh
-    - source: salt://elasticsearch/files/restart-elasticsearch.sh
-    - mode: 755
-    - require:
-      - pkg: apache2
-      - pkg: elasticsearch
-
-/etc/sudoers.d/90-restart-elasticsearch:
-  file.managed:
-    - source: salt://elasticsearch/files/sudoers.d/restart-elasticsearch
-    - mode: 440
-    # Salt appends to check_cmd a temporary file containing the new managed contents. This serves as the argument to `-f`.
-    - check_cmd: visudo -c -f
-    - require:
-      - file: /opt/restart-elasticsearch.sh
-
 /etc/elasticsearch/readonlyrest.yml:
   file.managed:
     - name: /etc/elasticsearch/readonlyrest.yml
@@ -46,10 +28,8 @@ readonlyrest-install:
     - key_values:
         # https://github.com/beshu-tech/readonlyrest-docs/blob/master/kibana.md#malformed-in-index-settings
         readonlyrest.force_load_from_file: 'true'
-        # https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#4-disable-x-pack-security-module
+        # https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#5-disable-x-pack-security-module
         xpack.security.enabled: 'false'
-        # https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#external-rest-api
-        http.type: ssl_netty4
     - separator: ': '
     - append_if_not_found: True
     - require:


### PR DESCRIPTION
This PR updates the docs server to Ubuntu 22.04 #381.
It also resolves ES SSL configuration issues #396 and #387, I have achieved this by moving ES behind Apache. 

**Questions**

1. From what I could see we are using one ES index `ocdsindex_en`? if we are using more I will need to reconfigure the proxy configuration as it is limiting access to one index.
2. What is the best way to populate ElasticSearch?
3. We need to update future docs deployments for the new ES URL (https://standard.open-contracting.org/ocdsindex_en/_search?size=100)

**Go live plan**

- [ ] Merge and deploy
- [ ] Copy `/home/ocds-docs/web` directory - `rsync -avz ocp07:/home/ocds-docs/web/ /home/ocds-docs/web/`
- [ ] Update references to old ES URL