### PR TITLE
Prometheus Ubuntu 22.04

### DIFF
--- a/docs/deploy/create_server.rst
+++ b/docs/deploy/create_server.rst
@@ -300,6 +300,11 @@ For Kingfisher servers (instructions are incomplete):
 
 For Redash servers, see :doc:`redash`.
 
+For Prometheus:
+
+#. Copy the ``/home/prometheus-server/data`` directory
+#. Update the IP addresses in the ``pillar/prometheus_client.sls`` file, and deploy to all services
+
 6. Update external services
 ---------------------------
 

--- a/docs/develop/update/firewall.rst
+++ b/docs/develop/update/firewall.rst
@@ -117,7 +117,7 @@ You can configure a Hetzner firewall as follows:
         -
         - Accept
       * - Allow Prometheus
-        - 213.138.113.219/32
+        - 139.162.253.17/32
         - 0.0.0.0/0
         - 0-65535
         - 7231
@@ -176,7 +176,7 @@ You can configure a Linode Cloud Firewall as follows:
          * - Allow-Prometheus
            - TCP
            - 7231
-           - 213.138.113.219/32, 2001:41c8:51:7db::219/128
+           - 139.162.253.17/32, 2a01:7e00::f03c:93ff:fe13:a12c/128
            - Accept
    
       Most servers will also have:

--- a/docs/develop/update/network.rst
+++ b/docs/develop/update/network.rst
@@ -21,7 +21,7 @@ Linux networking
 systemd-networkd
 ~~~~~~~~~~~~~~~~
 
-`systemd-networkd <https://manpages.ubuntu.com/manpages/jammy/man5/systemd.network.5.html>`__ is a system daemon to configure networking, and is our preferred solution for Linode instances. Configurations are available for `Linode`_ and other hosts. The configuration is written to ``/etc/systemd/network/05-eth0.network``.
+`systemd-networkd <https://manpages.ubuntu.com/manpages/jammy/man5/systemd.network.5.html>`__ is a system daemon to configure networking, and is our preferred solution for Linode instances. Configurations are available for Linode and other hosts. The configuration is written to ``/etc/systemd/network/05-eth0.network``.
 
 Linode template
 ^^^^^^^^^^^^^^^

--- a/pillar/maintenance.sls
+++ b/pillar/maintenance.sls
@@ -1,3 +1,0 @@
-maintenance:
-  enabled: True
-  patching: manual

--- a/pillar/prometheus_client.sls
+++ b/pillar/prometheus_client.sls
@@ -1,6 +1,6 @@
 firewall:
-  prometheus_ipv4: 213.138.113.219
-  prometheus_ipv6: 2001:41c8:51:7db::219
+  prometheus_ipv4: 139.162.253.17
+  prometheus_ipv6: 2a01:7e00::f03c:93ff:fe13:a12c
 
 prometheus:
   node_exporter:

--- a/pillar/prometheus_server.sls
+++ b/pillar/prometheus_server.sls
@@ -1,9 +1,17 @@
+network:
+  host_id: ocp20
+  ipv4: 139.162.253.17
+  #ipv6: 2a01:7e00::f03c:93ff:fe13:a12c
+  networkd:
+    template: linode
+    gateway4: 139.162.253.1
+
 prometheus:
   prometheus:
     service: prometheus-server
     user: prometheus-server
     basename: prometheus
-    version: 2.36.2
+    version: 2.37.6
     local_storage_retention: 120d
     config:
       conf-prometheus.yml: salt://prometheus/files/conf-prometheus.yml
@@ -13,7 +21,7 @@ prometheus:
     service: prometheus-alertmanager
     user: prometheus-alertmanager
     basename: alertmanager
-    version: 0.24.0
+    version: 0.25.0
     config:
       conf-alertmanager.yml: salt://prometheus/files/conf-alertmanager.yml
 

--- a/pillar/prometheus_server_maintenance.sls
+++ b/pillar/prometheus_server_maintenance.sls
@@ -1,0 +1,7 @@
+maintenance:
+  enabled: True
+  patching: manual
+  rkhunter_customisation: |
+    ALLOW_SSH_ROOT_USER=yes
+    RTKT_FILE_WHITELIST=/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.9
+    USER_FILEPROP_FILES_DIRS=/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.9

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -10,14 +10,12 @@ base:
     - cove_oc4ids
     - cove_oc4ids_maintenance
     - private.cove_oc4ids
-    - maintenance
 
   'cove-ocds':
     - cove
     - cove_ocds
     - cove_ocds_maintenance
     - private.cove_ocds
-    - maintenance
 
   'docs':
     - docs

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -41,7 +41,7 @@ base:
     - prometheus_server
     - private.smtp
     - private.prometheus_server
-    - maintenance
+    - prometheus_server_maintenance
 
   'redash':
     - redash

--- a/salt-config/roster
+++ b/salt-config/roster
@@ -5,7 +5,7 @@ cove-ocds:           ocp18.open-contracting.org
 docs:                ocp07.open-contracting.org
 kingfisher-process:  ocp04.open-contracting.org
 kingfisher-replica:  ocp05.open-contracting.org
-prometheus:          ocp03.open-contracting.org
+prometheus:          ocp20.open-contracting.org
 redash:              ocp14.open-contracting.org
 redmine:             ocp16.open-contracting.org
 registry:

--- a/salt/core/systemd/files/prometheus-alertmanager.service
+++ b/salt/core/systemd/files/prometheus-alertmanager.service
@@ -8,6 +8,7 @@ Group={{ user }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/home/{{ user }}/{{ entry.basename }}-{{ entry.version }}.{{ grains.kernel|lower }}-{{ grains.osarch }}/{{ entry.basename }} \
     --web.listen-address 127.0.0.1:9095 \
+    --cluster.listen-address ""\
     --config.file /home/{{ user }}/conf-alertmanager.yml \
 {%- if salt['pillar.get']('apache:sites:prometheus-alertmanager:servername') %}
     --web.external-url https://{{ pillar.apache.sites['prometheus-alertmanager'].servername }}/ \

--- a/salt/prometheus/files/conf-prometheus.yml
+++ b/salt/prometheus/files/conf-prometheus.yml
@@ -16,7 +16,7 @@ scrape_configs:
     'ocds-kingfisher-replica': 'ocp05.open-contracting.org',
     'ocds-kingfisher2': 'ocp04.open-contracting.org',
     'ocds-live.docs': 'ocp07.open-contracting.org',
-    'prometheus-server-node': 'ocp03.open-contracting.org',
+    'prometheus-server-node': 'ocp20.open-contracting.org',
     'data-registry': 'ocp13.open-contracting.org',
     'redash': 'ocp14.open-contracting.org',
     'redmine': 'ocp16.open-contracting.org',


### PR DESCRIPTION
This PR updates the prometheus server to Ubuntu 22.04 (#381)

**Go Live plan**

- [ ] Merge and deploy
- [ ] Populate the new Prometheus database
```bash
ssh ocp20
systemctl stop prometheus-server.service
rm -rf /home/prometheus-server/data/* # Remove temporary data
ssh ocp03 -p 8255
rsync -avz ocp03:/home/prometheus-server/data/ /home/prometheus-server/data/ # Populate database
systemctl start prometheus-server.service
```
- [ ] Update DNS
- [ ] Deploy firewall changes to all serversa