### PR TITLE
Coalition Server

### DIFF
--- a/docs/deploy/prometheus.rst
+++ b/docs/deploy/prometheus.rst
@@ -6,7 +6,7 @@ Monitor a service
 
 If the ``prometheus.node_exporter`` state file applies to the target, then `Node Exporter <https://github.com/prometheus/node_exporter>`__ is served on port 7231 using the HTTPS scheme and a self-signed certificate. Only connections from the Prometheus server are allowed.
 
-#. Add a job to ``salt/prometheus/server/files/config/conf-prometheus.yml``.
+#. Add a job to ``salt/prometheus/files/conf-prometheus.yml``.
 
 #. :doc:`Deploy<deploy>` the Prometheus service.
 

--- a/docs/develop/update/apache.rst
+++ b/docs/develop/update/apache.rst
@@ -224,6 +224,8 @@ apache.modules.proxy_uwsgi
   Provides supports for the `uWSGI protocol in ProxyPass directives <https://httpd.apache.org/docs/2.4/en/mod/mod_proxy_uwsgi.html>`__. Included by the ``python_apps`` state file.
 apache.modules.remoteip
   Adds `RemoteIPHeader, RemoteIPTrustedProxy and other directives <https://httpd.apache.org/docs/2.4/en/mod/mod_remoteip.html>`__.
+apache.modules.rewrite
+  Adds the `mod_rewrite rule-based rewriting engine to rewrite requested URLs on the fly <https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html>`__.
 apache.modules.ssl
   Included and required by ``apache.modules.md``.
 apache.modules.watchdog

--- a/docs/develop/update/index.rst
+++ b/docs/develop/update/index.rst
@@ -19,6 +19,7 @@ Make changes
    rabbitmq.rst
    python.rst
    docker.rst
+   wordpress.rst
    languages.rst
    logs.rst
    delete.rst

--- a/docs/develop/update/languages.rst
+++ b/docs/develop/update/languages.rst
@@ -1,10 +1,26 @@
-Configure Node.js and Ruby
-==========================
+Configure PHP, Node.js and Ruby
+===============================
+
+.. _php:
+
+Configure PHP
+-------------
+
+The `default version <https://endoflife.date/php>`__ is 8.1.
+
+To override or lock the version, update the server's Pillar file:
+
+.. code-block:: yaml
+
+   php:
+     version: '8.1'
 
 Configure Node.js
 -----------------
 
-In the service's Pillar file, add, for example:
+The `default version <https://endoflife.date/node>`__ is the latest LTS version, 18.
+
+To override or lock the version, update the server's Pillar file:
 
 .. code-block:: yaml
 

--- a/docs/develop/update/languages.rst
+++ b/docs/develop/update/languages.rst
@@ -6,7 +6,7 @@ Configure PHP, Node.js and Ruby
 Configure PHP
 -------------
 
-The `default version <https://endoflife.date/php>`__ is 8.1.
+The `default version <https://endoflife.date/php>`__ is the latest Ubuntu-managed version, 8.1.
 
 To override or lock the version, update the server's Pillar file:
 

--- a/docs/develop/update/mysql.rst
+++ b/docs/develop/update/mysql.rst
@@ -4,7 +4,7 @@ Configure MySQL
 Specify the version
 -------------------
 
-The default version is 8.0.
+The `default version <https://endoflife.date/mysql>`__ is 8.0.
 
 To override the version, update the server's Pillar file:
 

--- a/docs/develop/update/wordpress.rst
+++ b/docs/develop/update/wordpress.rst
@@ -21,26 +21,14 @@ In the service's Pillar file, add, for example:
            user: coalition
            socket: /var/run/php/php-fpm-coalition.sock
 
-MySQL
------
+MySQL and PHP
+-------------
+
+Follow the :doc:`MySQL` and :ref:`PHP` documentation.
 
 .. note::
 
    `The official WordPress distribution only supports the MySQL and MariaDB database engines <https://codex.wordpress.org/Using_Alternative_Databases>`__.
-
-Follow the :doc:`MySQL` documentation.
-
-PHP
----
-
-The `default version <https://endoflife.date/php>`__ is 8.1.
-
-To override the version, update the server's Pillar file:
-
-.. code-block:: yaml
-
-   php:
-     version: '8.1'
 
 PHP-FPM
 -------

--- a/docs/develop/update/wordpress.rst
+++ b/docs/develop/update/wordpress.rst
@@ -1,0 +1,123 @@
+Configure WordPress
+===================
+
+Apache
+------
+
+Follow the :doc:`Apache` documentation, using the ``wordpress`` configuration at the :ref:`apache-sites` step.
+
+In the service's Pillar file, add, for example:
+
+.. code-block:: yaml
+
+   apache:
+     public_access: True
+     sites:
+       coalition:
+         configuration: wordpress
+         servername: www.open-spending.eu
+         serveraliases: ['open-spending.eu']
+         context:
+           user: coalition
+           socket: /var/run/php/php-fpm-coalition.sock
+
+MySQL
+-----
+
+.. note::
+
+   `The official WordPress distribution only supports the MySQL and MariaDB database engines <https://codex.wordpress.org/Using_Alternative_Databases>`__.
+
+Follow the :doc:`MySQL` documentation.
+
+PHP
+---
+
+The `default version <https://endoflife.date/php>`__ is 8.1.
+
+To override the version, update the server's Pillar file:
+
+.. code-block:: yaml
+
+   php:
+     version: '8.1'
+
+PHP-FPM
+-------
+
+Configure `PHP-FPM <https://www.php.net/manual/en/install.fpm.php>`__ to correspond to the Apache configuration. For example:
+
+.. code-block:: yaml
+
+   phpfpm:
+     sites:
+       coalition:
+         configuration: default
+         context:
+           user: coalition
+           listen_user: www-data
+           socket: /var/run/php/php-fpm-coalition.sock
+
+.. note::
+
+   You can create a custom configuration, if needed.
+
+WordPress
+---------
+
+.. note::
+
+   Salt contains `WordPress states <https://docs.saltproject.io/en/latest/ref/states/all/salt.states.wordpress.html>`__, but they are limited. Also, WordPress is often deployed by copying files, rather than via fresh installs.
+
+#. Configure `WP-CLI <https://wp-cli.org>`__. In the service's Pillar file, add, for example:
+
+   .. code-block:: yaml
+
+      wordpress:
+        cli_version: 2.7.1
+
+#. :doc:`Deploy the service<deploy>`.
+
+#. Connect to the server as the WordPress user, for example:
+
+   .. code-block:: bash
+
+      curl --silent --connect-timeout 1 ocp21.open-contracting.org:8255 || true
+      ssh coalition@ocp21.open-contracting.org
+
+#. Change to the ``public_html`` directory:
+
+   .. code-block:: bash
+
+      cd ~/public_html
+
+#. Download WordPress:
+
+   .. code-block:: bash
+
+      wp core download --locale=en_US
+
+#. Configure WordPress' database connection, to correspond to the MySQL configuration. For example:
+
+   .. code-block:: bash
+
+      wp core config --dbname=DBNAME --dbuser=USERNAME --dbpass=PASSWORD
+
+#. Install WordPress, with a ``siteadmin`` user associated to ``sysadmin@open-contracting.org``. For example:
+
+   .. code-block:: bash
+
+      wp core install --url=www.open-spending.eu --title="www.open-spending.eu" --admin_user=siteadmin --admin_password=PASSWORD --admin_email=sysadmin@open-contracting.org --skip-email
+
+#. Uninstall default plugins:
+
+   .. code-block:: bash
+
+      wp plugin uninstall hello
+
+#. If you have a custom theme, download and activate it. For example:
+
+   .. code-block:: bash
+
+      git -C wp-content/themes/ clone git@github.com:open-contracting-partnership/www.open-spending.eu.git
+      wp theme activate www.open-spending.eu

--- a/pillar/coalition.sls
+++ b/pillar/coalition.sls
@@ -14,8 +14,6 @@ apache:
       serveraliases: ['open-spending.eu']
       context:
         php_socket: /var/run/php/php-fpm-coalition.sock
-#      htpasswd: # For wp-admin
-#        basicauth: example
 
 phpfpm:
   sites:

--- a/pillar/coalition.sls
+++ b/pillar/coalition.sls
@@ -9,11 +9,12 @@ apache:
   public_access: True
   sites:
     coalition:
-      configuration: coalition
+      configuration: wordpress
       servername: www.open-spending.eu
       serveraliases: ['open-spending.eu']
       context:
-        php_socket: /var/run/php/php-fpm-coalition.sock
+        user: coalition
+        socket: /var/run/php/php-fpm-coalition.sock
 
 phpfpm:
   sites:
@@ -30,8 +31,6 @@ mysql:
   databases:
     coalition_wp:
       user: coalition
-#  backup:
-#    location: ocp-coalition-backups/database
 
 wordpress:
   cli_version: 2.7.1

--- a/pillar/coalition.sls
+++ b/pillar/coalition.sls
@@ -16,6 +16,9 @@ apache:
         user: coalition
         socket: /var/run/php/php-fpm-coalition.sock
 
+php:
+  version: '8.1'
+
 phpfpm:
   sites:
     coalition:

--- a/pillar/coalition.sls
+++ b/pillar/coalition.sls
@@ -1,0 +1,39 @@
+network:
+  host_id: ocp21
+  ipv4: 139.162.211.65
+  networkd:
+    template: linode
+    gateway4: 139.162.211.1
+
+apache:
+  public_access: True
+  sites:
+    coalition:
+      configuration: coalition
+      servername: www.open-spending.eu
+      serveraliases: ['open-spending.eu']
+      context:
+        php_socket: /var/run/php/php-fpm-coalition.sock
+#      htpasswd: # For wp-admin
+#        basicauth: example
+
+phpfpm:
+  sites:
+    coalition:
+      configuration: default
+      context:
+        user: coalition
+        listen_user: www-data
+        socket: /var/run/php/php-fpm-coalition.sock
+
+mysql:
+  version: '8.0'
+  configuration: False
+  databases:
+    coalition_wp:
+      user: coalition
+#  backup:
+#    location: ocp-coalition-backups/database
+
+wordpress:
+  cli_version: 2.7.1

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -5,6 +5,10 @@ base:
     - common
     - private.common
 
+  'coalition':
+    - coalition
+    - private.coalition
+
   'cove-oc4ids':
     - cove
     - cove_oc4ids

--- a/salt-config/roster
+++ b/salt-config/roster
@@ -1,5 +1,6 @@
 # Defines the potential targets of the salt-ssh command.
 
+coalition:           ocp21.open-contracting.org
 cove-oc4ids:         ocp17.open-contracting.org
 cove-ocds:           ocp18.open-contracting.org
 docs:                ocp19.open-contracting.org

--- a/salt/apache/files/sites/coalition.conf.include
+++ b/salt/apache/files/sites/coalition.conf.include
@@ -1,0 +1,16 @@
+DocumentRoot /home/coalition/public_html
+<Directory /home/coalition/public_html>
+    Options FollowSymLinks
+    AllowOverride Limit Options FileInfo
+    DirectoryIndex index.php
+    Require all granted
+</Directory>
+
+<Directory /home/coalition/public_html/wp-content>
+    Options FollowSymLinks
+    Require all granted
+</Directory>
+
+<FilesMatch \.php$>
+  SetHandler "proxy:unix:{{ php_socket }}|fcgi://localhost/"
+</FilesMatch>

--- a/salt/apache/files/sites/coalition.conf.include
+++ b/salt/apache/files/sites/coalition.conf.include
@@ -14,3 +14,10 @@ DocumentRoot /home/coalition/public_html
 <FilesMatch \.php$>
   SetHandler "proxy:unix:{{ php_socket }}|fcgi://localhost/"
 </FilesMatch>
+
+<FilesMatch "^(wp-admin|wp-login\.php)">
+    AuthType Basic
+    AuthName "Restricted Area"
+    AuthUserFile /etc/apache2/.htpasswd-coalition
+    Require valid-user
+</FilesMatch>

--- a/salt/apache/files/sites/wordpress.conf.include
+++ b/salt/apache/files/sites/wordpress.conf.include
@@ -1,23 +1,24 @@
-DocumentRoot /home/coalition/public_html
-<Directory /home/coalition/public_html>
+DocumentRoot /home/{{ user }}/public_html
+
+<Directory /home/{{ user }}/public_html>
     Options FollowSymLinks
     AllowOverride Limit Options FileInfo
     DirectoryIndex index.php
     Require all granted
 </Directory>
 
-<Directory /home/coalition/public_html/wp-content>
+<Directory /home/{{ user }}/public_html/wp-content>
     Options FollowSymLinks
     Require all granted
 </Directory>
 
 <FilesMatch \.php$>
-  SetHandler "proxy:unix:{{ php_socket }}|fcgi://localhost/"
+    SetHandler "proxy:unix:{{ socket }}|fcgi://localhost/"
 </FilesMatch>
 
 <FilesMatch "^(wp-admin|wp-login\.php)">
     AuthType Basic
     AuthName "Restricted Area"
-    AuthUserFile /etc/apache2/.htpasswd-coalition
+    AuthUserFile /etc/apache2/.htpasswd-{{ user }}
     Require valid-user
 </FilesMatch>

--- a/salt/apache/modules/proxy_fcgi.sls
+++ b/salt/apache/modules/proxy_fcgi.sls
@@ -1,0 +1,8 @@
+include:
+  - apache
+  - apache.modules.proxy
+
+proxy_fcgi:
+  apache_module.enabled:
+    - watch_in:
+      - service: apache2

--- a/salt/coalition/init.sls
+++ b/salt/coalition/init.sls
@@ -1,0 +1,35 @@
+{% from 'lib.sls' import create_user %}
+  
+{% set user = 'coalition' %}
+{% set userdir = '/home/' + user %}
+
+include:
+  - apache
+  - apache.modules.rewrite
+  - php-fpm
+
+wp-cli:
+  file.managed:
+    - name: /usr/local/bin/wp
+    - source: https://github.com/wp-cli/wp-cli/releases/download/v{{ pillar.wordpress.cli_version }}/wp-cli-{{ pillar.wordpress.cli_version }}.phar
+    - mode: 755
+    - source_hash: https://github.com/wp-cli/wp-cli/releases/download/v{{ pillar.wordpress.cli_version }}/wp-cli-{{ pillar.wordpress.cli_version }}.phar.sha512
+
+{{ create_user(user) }}
+
+allow {{ userdir }} access:
+  file.directory:
+    - name: {{ userdir }}
+    - user: {{ user }}
+    - group: {{ user }}
+    - mode: 755
+    - require:
+      - user: {{ user }}_user_exists
+
+{{ userdir }}/public_html:
+  file.directory:
+    - user: {{ user }}
+    - group: {{ user }}
+    - mode: 755
+    - require:
+      - user: {{ user }}_user_exists

--- a/salt/coalition/init.sls
+++ b/salt/coalition/init.sls
@@ -12,8 +12,8 @@ wp-cli:
   file.managed:
     - name: /usr/local/bin/wp
     - source: https://github.com/wp-cli/wp-cli/releases/download/v{{ pillar.wordpress.cli_version }}/wp-cli-{{ pillar.wordpress.cli_version }}.phar
-    - mode: 755
     - source_hash: https://github.com/wp-cli/wp-cli/releases/download/v{{ pillar.wordpress.cli_version }}/wp-cli-{{ pillar.wordpress.cli_version }}.phar.sha512
+    - mode: 755
 
 {{ create_user(user) }}
 

--- a/salt/coalition/init.sls
+++ b/salt/coalition/init.sls
@@ -20,8 +20,6 @@ wp-cli:
 allow {{ userdir }} access:
   file.directory:
     - name: {{ userdir }}
-    - user: {{ user }}
-    - group: {{ user }}
     - mode: 755
     - require:
       - user: {{ user }}_user_exists

--- a/salt/core/network/init.sls
+++ b/salt/core/network/init.sls
@@ -47,8 +47,9 @@ set hostname:
     - template: jinja
 
 systemd-networkd:
-  service.enabled:
+  service.running:
     - name: systemd-networkd
+    - enable: True
 {% elif 'netplan' in pillar.network %}
 /etc/netplan/01-netcfg.yaml:
   file.absent

--- a/salt/php-fpm/files/default.conf
+++ b/salt/php-fpm/files/default.conf
@@ -1,0 +1,8 @@
+[{{ user }}]
+user = {{ user }}
+group = {{ user }}
+listen = {{ socket }}
+listen.owner = {{ listen_user }}
+listen.group = {{ listen_user }}
+pm = static
+pm.max_children = 10

--- a/salt/php-fpm/init.sls
+++ b/salt/php-fpm/init.sls
@@ -15,7 +15,7 @@ php-fpm:
     - name: php{{ php_version }}-fpm
     - enable: True
     - require:
-      - pkg: apache2
+      - pkg: php-fpm
 
 php-fpm-reload:
   module.wait:

--- a/salt/php-fpm/init.sls
+++ b/salt/php-fpm/init.sls
@@ -1,18 +1,16 @@
-{% set version = '8.1' %}
-
 include:
   - apache.modules.proxy_fcgi
 
 php-fpm:
   pkg.installed:
-    - name: php{{ version }}-fpm
+    - name: php{{ pillar.php.version }}-fpm
   file.rename:
-    - source: /etc/php/{{ version }}/fpm/pool.d/www.conf
-    - name: /etc/php/{{ version }}/fpm/pool.d/www.conf.disabled
+    - source: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf
+    - name: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf.disabled
     - require:
       - pkg: php-fpm
   service.running:
-    - name: php{{ version}}-fpm
+    - name: php{{ pillar.php.version }}-fpm
     - enable: True
     - require:
       - pkg: apache2
@@ -21,13 +19,13 @@ php-fpm:
 php-fpm-reload:
   module.wait:
     - name: service.reload
-    - m_name: php{{ version }}-fpm.service
+    - m_name: php{{ pillar.php.version }}-fpm.service
 
 {% for name, entry in pillar.phpfpm.sites.items() %}
 php configure {{ name }}:
   file.managed:
     - source: salt://php-fpm/files/{{ entry.configuration }}.conf
-    - name: /etc/php/{{ version }}/fpm/pool.d/{{ name }}.conf
+    - name: /etc/php/{{ pillar.php.version }}/fpm/pool.d/{{ name }}.conf
     - template: jinja
     - context: {{ dict(entry.context, name=name, **entry.get('context', {}))|yaml }}
     - require:
@@ -39,9 +37,9 @@ php configure {{ name }}:
 php modules:
   pkg.installed:
     - pkgs:
-      - php{{ version }}-curl
-      - php{{ version }}-mbstring
-      - php{{ version }}-mysql
-      - php{{ version }}-xml
+      - php{{ pillar.php.version }}-curl
+      - php{{ pillar.php.version }}-mbstring
+      - php{{ pillar.php.version }}-mysql
+      - php{{ pillar.php.version }}-xml
     - watch_in:
       - service: php-fpm

--- a/salt/php-fpm/init.sls
+++ b/salt/php-fpm/init.sls
@@ -5,8 +5,8 @@ php-fpm:
   pkg.installed:
     - name: php{{ pillar.php.version }}-fpm
   file.rename:
-    - source: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf
     - name: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf.disabled
+    - source: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf
     - require:
       - pkg: php-fpm
   service.running:
@@ -15,19 +15,18 @@ php-fpm:
     - require:
       - pkg: apache2
 
-
 php-fpm-reload:
   module.wait:
     - name: service.reload
     - m_name: php{{ pillar.php.version }}-fpm.service
 
 {% for name, entry in pillar.phpfpm.sites.items() %}
-php configure {{ name }}:
+/etc/php/-/fpm/pool.d/{{ name }}.conf:
   file.managed:
-    - source: salt://php-fpm/files/{{ entry.configuration }}.conf
     - name: /etc/php/{{ pillar.php.version }}/fpm/pool.d/{{ name }}.conf
+    - source: salt://php-fpm/files/{{ entry.configuration }}.conf
     - template: jinja
-    - context: {{ dict(entry.context, name=name, **entry.get('context', {}))|yaml }}
+    - context: {{ entry.context|yaml }}
     - require:
       - pkg: php-fpm
     - watch_in:

--- a/salt/php-fpm/init.sls
+++ b/salt/php-fpm/init.sls
@@ -1,16 +1,18 @@
+{% set php_version = pillar.php.get('version', '8.1') %}
+
 include:
   - apache.modules.proxy_fcgi
 
 php-fpm:
   pkg.installed:
-    - name: php{{ pillar.php.version }}-fpm
+    - name: php{{ php_version }}-fpm
   file.rename:
-    - name: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf.disabled
-    - source: /etc/php/{{ pillar.php.version }}/fpm/pool.d/www.conf
+    - name: /etc/php/{{ php_version }}/fpm/pool.d/www.conf.disabled
+    - source: /etc/php/{{ php_version }}/fpm/pool.d/www.conf
     - require:
       - pkg: php-fpm
   service.running:
-    - name: php{{ pillar.php.version }}-fpm
+    - name: php{{ php_version }}-fpm
     - enable: True
     - require:
       - pkg: apache2
@@ -18,12 +20,12 @@ php-fpm:
 php-fpm-reload:
   module.wait:
     - name: service.reload
-    - m_name: php{{ pillar.php.version }}-fpm.service
+    - m_name: php{{ php_version }}-fpm.service
 
 {% for name, entry in pillar.phpfpm.sites.items() %}
 /etc/php/-/fpm/pool.d/{{ name }}.conf:
   file.managed:
-    - name: /etc/php/{{ pillar.php.version }}/fpm/pool.d/{{ name }}.conf
+    - name: /etc/php/{{ php_version }}/fpm/pool.d/{{ name }}.conf
     - source: salt://php-fpm/files/{{ entry.configuration }}.conf
     - template: jinja
     - context: {{ entry.context|yaml }}
@@ -36,9 +38,9 @@ php-fpm-reload:
 php modules:
   pkg.installed:
     - pkgs:
-      - php{{ pillar.php.version }}-curl
-      - php{{ pillar.php.version }}-mbstring
-      - php{{ pillar.php.version }}-mysql
-      - php{{ pillar.php.version }}-xml
+      - php{{ php_version }}-curl
+      - php{{ php_version }}-mbstring
+      - php{{ php_version }}-mysql
+      - php{{ php_version }}-xml
     - watch_in:
       - service: php-fpm

--- a/salt/php-fpm/init.sls
+++ b/salt/php-fpm/init.sls
@@ -1,0 +1,47 @@
+{% set version = '8.1' %}
+
+include:
+  - apache.modules.proxy_fcgi
+
+php-fpm:
+  pkg.installed:
+    - name: php{{ version }}-fpm
+  file.rename:
+    - source: /etc/php/{{ version }}/fpm/pool.d/www.conf
+    - name: /etc/php/{{ version }}/fpm/pool.d/www.conf.disabled
+    - require:
+      - pkg: php-fpm
+  service.running:
+    - name: php{{ version}}-fpm
+    - enable: True
+    - require:
+      - pkg: apache2
+
+
+php-fpm-reload:
+  module.wait:
+    - name: service.reload
+    - m_name: php{{ version }}-fpm.service
+
+{% for name, entry in pillar.phpfpm.sites.items() %}
+php configure {{ name }}:
+  file.managed:
+    - source: salt://php-fpm/files/{{ entry.configuration }}.conf
+    - name: /etc/php/{{ version }}/fpm/pool.d/{{ name }}.conf
+    - template: jinja
+    - context: {{ dict(entry.context, name=name, **entry.get('context', {}))|yaml }}
+    - require:
+      - pkg: php-fpm
+    - watch_in:
+      - module: php-fpm-reload
+{% endfor %}
+
+php modules:
+  pkg.installed:
+    - pkgs:
+      - php{{ version }}-curl
+      - php{{ version }}-mbstring
+      - php{{ version }}-mysql
+      - php{{ version }}-xml
+    - watch_in:
+      - service: php-fpm

--- a/salt/prometheus/files/conf-prometheus.yml
+++ b/salt/prometheus/files/conf-prometheus.yml
@@ -11,6 +11,7 @@ scrape_configs:
 
   # Node Exporter.
 {%- for job_name, host in {
+    'coalition': 'ocp21.open-contracting.org',
     'cove-oc4ids-2': 'ocp17.open-contracting.org',
     'cove-ocds-2': 'ocp18.open-contracting.org',
     'ocds-kingfisher-replica': 'ocp05.open-contracting.org',

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -19,6 +19,9 @@ base:
     - core.systemd.logind
     - core.systemd.ntp
 
+  'coalition':
+    - coalition
+
   'cove-*':
     - cove
 


### PR DESCRIPTION
PR adds new ocp21, WordPress hosting server for open-spending.eu.

You can test the new site by overwriting your hosts file as follows:
> 139.162.211.65 www.open-spending.eu open-spending.eu

I have configured a self signed SSL cert so you will see an SSL warning until DNS is live.

I have installed WordPress and the new theme (https://github.com/open-contracting-partnership/www.open-spending.eu)
The site will need content changes before we can go live.