### PR TITLE
Salt 3006 Onedir support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /salt-config/master
 /salt-config/master.d
 /salt-config/pki
+/Saltfile
 # Locations set salt-config/master.d/localuser.conf
 /cache
 /log

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 #!/bin/sh
 # https://superuser.com/a/1622435/1803567
-"""$(dirname $(which salt-ssh))"/bin/python3 - "$@" <<"EOF"""
+"""$(dirname $(readlink $(which salt-ssh) || which salt-ssh))"/bin/python3 - "$@" <<"EOF"""
 
 import os
 import socket

--- a/run.py
+++ b/run.py
@@ -1,6 +1,6 @@
 #!/bin/sh
 # https://superuser.com/a/1622435/1803567
-"""$(dirname $(which salt-ssh))"/bin/python3 - "$@" <<"EOF"""
+"""$(dirname $(readlink $(which salt-ssh) || which salt-ssh))"/bin/python3 - "$@" <<"EOF"""
 
 import os
 import socket
@@ -8,7 +8,6 @@ import sys
 
 import salt.cli.ssh
 import salt.client.ssh
-
 
 def main():
     # Replace program name to match Saltfile.

--- a/script/setup
+++ b/script/setup
@@ -17,7 +17,7 @@ echo "salt-ssh:
   extra_filerefs:
     - $REPO_DIR/salt/apache/includes/cove.include.jinja
     - $REPO_DIR/salt/postgres/files/conf/shared.include
-" > ~/.salt/Saltfile
+" > Saltfile
 
 echo "# https://docs.saltproject.io/en/latest/ref/configuration/master.html#std-conf_master-file_roots
 file_roots:


### PR DESCRIPTION
+ Added relative `Saltfile` configuration to prevent clashing with other salt deployments installed.
+ Following salt-ssh symlinks to find the python3 binary, this was broken on Debian based systems.