### PR TITLE
postgres: Use Let's Encrypt certificates for PostgreSQL if postgres.ssl.servername is set

### DIFF
--- a/pillar/kingfisher_main.sls
+++ b/pillar/kingfisher_main.sls
@@ -48,7 +48,6 @@ apache:
   modules:
     mod_md:
       MDNotifyCmd: /opt/postgresql-certificates-wrapper.sh
-      MDCertificateAuthority: https://acme-staging-v02.api.letsencrypt.org/directory
   sites:
     kingfisher-collect:
       configuration: proxy

--- a/pillar/kingfisher_main.sls
+++ b/pillar/kingfisher_main.sls
@@ -45,6 +45,10 @@ logrotate:
 
 apache:
   public_access: True
+  modules:
+    mod_md:
+      MDNotifyCmd: /opt/postgresql-certificates-wrapper.sh
+      MDCertificateAuthority: https://acme-staging-v02.api.letsencrypt.org/directory
   sites:
     kingfisher-collect:
       configuration: proxy
@@ -69,6 +73,8 @@ postgres:
   version: 15
   # Public access allows Docker connections. Hetzner's firewall prevents non-local connections.
   public_access: True
+  ssl:
+    servername: postgres.kingfisher.open-contracting.org
   configuration:
     name: kingfisher-main1
     source: shared

--- a/salt/postgres/files/ssl/postgresql-certificates-wrapper.sh
+++ b/salt/postgres/files/ssl/postgresql-certificates-wrapper.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo /opt/postgresql-certificates.sh "$1"

--- a/salt/postgres/files/ssl/postgresql-certificates.sh
+++ b/salt/postgres/files/ssl/postgresql-certificates.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1083
 cp /etc/apache2/md/domains/"$1"/pubcert.pem /etc/apache2/md/domains/"$1"/privkey.pem /etc/postgresql/{{ pillar.postgres.version }}/main/
+# shellcheck disable=SC1083
 chown postgres:postgres /etc/postgresql/{{ pillar.postgres.version }}/main/pubcert.pem /etc/postgresql/{{ pillar.postgres.version }}/main/privkey.pem
 systemctl restart postgresql

--- a/salt/postgres/files/ssl/postgresql-certificates.sh
+++ b/salt/postgres/files/ssl/postgresql-certificates.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+if [ -d /etc/apache2/md/staging/"$1" ]; then
+  DIRECTORY=staging
+else
+  DIRECTORY=domains
+fi
 # shellcheck disable=SC1083
-cp /etc/apache2/md/domains/"$1"/pubcert.pem /etc/apache2/md/domains/"$1"/privkey.pem /etc/postgresql/{{ pillar.postgres.version }}/main/
+cp /etc/apache2/md/"$DIRECTORY"/"$1"/pubcert.pem /etc/apache2/md/"$DIRECTORY"/"$1"/privkey.pem /etc/postgresql/{{ pillar.postgres.version }}/main/
 # shellcheck disable=SC1083
 chown postgres:postgres /etc/postgresql/{{ pillar.postgres.version }}/main/pubcert.pem /etc/postgresql/{{ pillar.postgres.version }}/main/privkey.pem
 systemctl restart postgresql

--- a/salt/postgres/files/ssl/postgresql-certificates.sh
+++ b/salt/postgres/files/ssl/postgresql-certificates.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cp /etc/apache2/md/domains/"$1"/pubcert.pem /etc/apache2/md/domains/"$1"/privkey.pem /etc/postgresql/{{ pillar.postgres.version }}/main/
+chown postgres:postgres /etc/postgresql/{{ pillar.postgres.version }}/main/pubcert.pem /etc/postgresql/{{ pillar.postgres.version }}/main/privkey.pem
+systemctl restart postgresql

--- a/salt/postgres/files/ssl/sudoers
+++ b/salt/postgres/files/ssl/sudoers
@@ -1,0 +1,1 @@
+www-data ALL=(root) NOPASSWD: /opt/postgresql-certificates.sh


### PR DESCRIPTION
closes #440 

Note that MDCertificateAuthority is set to https://acme-staging-v02.api.letsencrypt.org/directory in pillar/kingfisher_main.sls so that we can remove and get new certificates without going over the rate limit.

I think I have everything configured correctly, and running:

```bash
sudo -u www-data /opt/postgresql-certificates-wrapper.sh "postgres.kingfisher.open-contracting.org"
```

yields the correct result. However, this either isn't being run by MDNotifyCmd, or it's encountering an error (but I don't know how to find a relevant log).