### PR TITLE
kingfisher: mount users directory to ease local loads

### DIFF
--- a/salt/docker_apps/files/kingfisher_process.yaml
+++ b/salt/docker_apps/files/kingfisher_process.yaml
@@ -11,10 +11,10 @@ x-filesystem: &filesystem
   volumes:
     # The right-hand path must match the settings.KINGFISHER_COLLECT_FILES_STORE default value in kingfisher-process.
     - {{ pillar.kingfisher_collect.env.FILES_STORE }}:/data
-    # For processing local loads.
-    {% for user, authorized_keys in pillar.users.items() %}
+    {# To run the load command. #}
+    {%- for user in pillar.users|default({}) %}
     - /home/{{user}}/local-load:/home/{{user}}/local-load
-    {% endfor %}
+    {%- endfor %}
 
 services:
   web:

--- a/salt/docker_apps/files/kingfisher_process.yaml
+++ b/salt/docker_apps/files/kingfisher_process.yaml
@@ -11,6 +11,7 @@ x-filesystem: &filesystem
   volumes:
     # The right-hand path must match the settings.KINGFISHER_COLLECT_FILES_STORE default value in kingfisher-process.
     - {{ pillar.kingfisher_collect.env.FILES_STORE }}:/data
+    # For processing local loads.
     {% for user, authorized_keys in pillar.users.items() %}
     - /home/{{user}}/local-load:/home/{{user}}/local-load
     {% endfor %}

--- a/salt/docker_apps/files/kingfisher_process.yaml
+++ b/salt/docker_apps/files/kingfisher_process.yaml
@@ -11,6 +11,9 @@ x-filesystem: &filesystem
   volumes:
     # The right-hand path must match the settings.KINGFISHER_COLLECT_FILES_STORE default value in kingfisher-process.
     - {{ pillar.kingfisher_collect.env.FILES_STORE }}:/data
+    {% for user, authorized_keys in pillar.users.items() %}
+    - /home/{{user}}/local-load:/home/{{user}}/local-load
+    {% endfor %}
 
 services:
   web:


### PR DESCRIPTION
I used the same directory structure in the containers so that we can use the current command and approach without changes