### PR TITLE
python: Allow installing another Python version

### DIFF
--- a/pillar/registry.sls
+++ b/pillar/registry.sls
@@ -93,6 +93,9 @@ docker:
   docker_compose:
     version: 1.29.2
 
+python:
+  version: '3.10'
+
 kingfisher_collect:
   user: collect
   group: deployer

--- a/salt/kingfisher/collect/init.sls
+++ b/salt/kingfisher/collect/init.sls
@@ -1,6 +1,7 @@
 {% from 'lib.sls' import create_user, set_cron_env, systemd %}
 
 include:
+  - python
   - python.virtualenv
   - python.extensions # twisted
   - python.psycopg2
@@ -59,7 +60,7 @@ allow {{ userdir }} access:
 
 {{ directory }}/.ve:
   virtualenv.managed:
-    - python: /usr/bin/python3
+    - python: /usr/bin/python{{ salt['pillar.get']('python:version', 3) }}
     - user: {{ user }}
     - system_site_packages: False
     - pip_pkgs:
@@ -67,6 +68,10 @@ allow {{ userdir }} access:
     - require:
       - pkg: virtualenv
       - file: {{ directory }}
+{% if salt['pillar.get']('python:version') %}
+    - watch:
+      - pkg: python
+{% endif %}
 
 {{ directory }}-requirements:
   cmd.run:

--- a/salt/python/extensions.sls
+++ b/salt/python/extensions.sls
@@ -1,6 +1,9 @@
+include:
+  - python
+
 python c extensions:
   pkg.installed:
     - pkgs:
-      - python3-dev
+      - python{{ salt['pillar.get']('python:version', 3) }}-dev
       - build-essential
       - libffi-dev

--- a/salt/python/init.sls
+++ b/salt/python/init.sls
@@ -1,0 +1,11 @@
+{% if salt['pillar.get']('python:version') %}
+python:
+  pkgrepo.managed:
+    - ppa: deadsnakes/ppa
+  pkg.installed:
+    - pkgs:
+      - python{{ pillar.python.version }}
+      - python{{ pillar.python.version }}-distutils
+    - require:
+      - pkgrepo: python
+{% endif %}

--- a/salt/python/psycopg2.sls
+++ b/salt/python/psycopg2.sls
@@ -1,6 +1,9 @@
+include:
+  - python
+
 # https://www.psycopg.org/install/
 psycopg2:
   pkg.installed:
     - pkgs:
-      - python3-dev
+      - python{{ salt['pillar.get']('python:version', 3) }}-dev
       - libpq-dev

--- a/salt/python/virtualenv.sls
+++ b/salt/python/virtualenv.sls
@@ -1,3 +1,6 @@
+include:
+  - python
+
 virtualenv:
   pkg.installed:
     - pkgs:

--- a/salt/python_apps.sls
+++ b/salt/python_apps.sls
@@ -12,6 +12,7 @@ include:
   - apache.modules.proxy_http
   - apache.modules.proxy_uwsgi
 {% endif %}
+  - python
   - python.virtualenv
 
 # Inspired by the Apache formula, which loops over sites to configure. See example in readme.
@@ -39,7 +40,7 @@ include:
 
 {{ directory }}/.ve:
   virtualenv.managed:
-    - python: /usr/bin/python3
+    - python: /usr/bin/python{{ salt['pillar.get']('python:version', 3) }}
     - user: {{ entry.user }}
     - system_site_packages: False
     - pip_pkgs:
@@ -50,6 +51,10 @@ include:
     - require:
       - pkg: virtualenv
       - git: {{ entry.git.url }}
+{% if salt['pillar.get']('python:version') %}
+    - watch:
+      - pkg: python
+{% endif %}
 
 {{ directory }}-requirements:
   cmd.run:


### PR DESCRIPTION
These states cause an error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/__main__.py", line 19, in <module>
    sys.exit(_main())
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_internal/cli/main.py", line 73, in main
    command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_internal/commands/__init__.py", line 96, in create_command
    module = importlib.import_module(module_path)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_internal/commands/install.py", line 24, in <module>
    from pip._internal.cli.req_command import RequirementCommand
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_internal/cli/req_command.py", line 15, in <module>
    from pip._internal.index.package_finder import PackageFinder
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_internal/index/package_finder.py", line 21, in <module>
    from pip._internal.index.collector import parse_links
  File "/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_internal/index/collector.py", line 12, in <module>
    from pip._vendor import html5lib, requests
ImportError: cannot import name 'html5lib' from 'pip._vendor' (/home/collect/scrapyd/.ve/lib/python3.10/site-packages/pip/_vendor/__init__.py)
```

I tried (commenting out `onchanges` on the first run):

```yaml
upgrade pip:
  cmd.run:
    - name: curl -sS https://bootstrap.pypa.io/get-pip.py | python{{ pillar.python.version }}
    - onchanges:
      - pkg: python
```

But this replaces the system pip, whereas we need to somehow replace the virtualenv's pip, before the rest of `virtualenv.managed` runs.

Adding `pip` to `pip_pkgs` and `pip_upgrade: True` under `virtualenv.managed` doesn't work, because pip can't upgrade itself due to the above error.
