### PR TITLE
feat: disable apache version numbers

### DIFF
--- a/salt/apache/init.sls
+++ b/salt/apache/init.sls
@@ -85,16 +85,21 @@ disable site 000-default.conf:
   file.absent:
     - name: /var/www/html/index.html
 
+# Ensure this configuration is loaded after security.conf, provided by the package.
 /etc/apache2/conf-available/zz-customization.conf:
   file.managed:
     - contents: |
        ServerTokens Prod
        ServerSignature Off
+    - require:
+      - pkg: apache2
+    - watch_in:
+      - module: apache2-reload
 
 enable customization config:
   apache_conf.enabled:
     - name: zz-customization
-    - watch:
+    - require:
       - file: /etc/apache2/conf-available/zz-customization.conf
     - watch_in:
       - module: apache2-reload

--- a/salt/apache/init.sls
+++ b/salt/apache/init.sls
@@ -96,7 +96,7 @@ disable site 000-default.conf:
     - watch_in:
       - module: apache2-reload
 
-enable customization config:
+enable conf zz-customization.conf:
   apache_conf.enabled:
     - name: zz-customization
     - require:

--- a/salt/apache/init.sls
+++ b/salt/apache/init.sls
@@ -85,6 +85,20 @@ disable site 000-default.conf:
   file.absent:
     - name: /var/www/html/index.html
 
+/etc/apache2/conf-available/zz-customization.conf:
+  file.managed:
+    - contents: |
+       ServerTokens Prod
+       ServerSignature Off
+
+enable customization config:
+  apache_conf.enabled:
+    - name: zz-customization
+    - watch:
+      - file: /etc/apache2/conf-available/zz-customization.conf
+    - watch_in:
+      - module: apache2-reload
+
 {% for name, entry in salt['pillar.get']('apache:sites', {}).items() %}
 {{ apache(name, entry) }}
 {% endfor %}

--- a/salt/docker_apps/files/redash.yaml
+++ b/salt/docker_apps/files/redash.yaml
@@ -18,6 +18,8 @@ services:
       - server
     links:
       - server:redash
+    volumes:
+      - /data/deploy/redash/files/nginx-security.conf:/etc/nginx/conf.d/security.conf
     restart: always
   redis:
     image: bitnami/redis:6.2

--- a/salt/docker_apps/files/redash.yaml
+++ b/salt/docker_apps/files/redash.yaml
@@ -19,7 +19,7 @@ services:
     links:
       - server:redash
     volumes:
-      - /data/deploy/redash/files/nginx-security.conf:/etc/nginx/conf.d/security.conf
+      - {{ directory }}/files/nginx-security.conf:/etc/nginx/conf.d/security.conf
     restart: always
   redis:
     image: bitnami/redis:6.2

--- a/salt/docker_apps/init.sls
+++ b/salt/docker_apps/init.sls
@@ -11,13 +11,13 @@ include:
   file.managed:
     - source: salt://docker_apps/files/{{ name }}.yaml
     - template: jinja
+    - context:
+        directory: {{ directory }}
     - user: {{ pillar.docker.user }}
     - group: {{ pillar.docker.user }}
     - makedirs: True
     - require:
       - user: {{ pillar.docker.user }}_user_exists
-    - context:
-        directory: {{ directory }}
 
 {{ directory }}/.env:
   file.managed:

--- a/salt/docker_apps/init.sls
+++ b/salt/docker_apps/init.sls
@@ -16,6 +16,8 @@ include:
     - makedirs: True
     - require:
       - user: {{ pillar.docker.user }}_user_exists
+    - context:
+        directory: {{ directory }}
 
 {{ directory }}/.env:
   file.managed:

--- a/salt/redash/init.sls
+++ b/salt/redash/init.sls
@@ -1,7 +1,12 @@
+{% from 'docker_apps/init.sls' import docker_apps_directory %}
+
 include:
   - docker_apps
 
-/data/deploy/redash/files/nginx-security.conf:
+{% set entry = pillar.docker_apps.redash %}
+{% set directory = docker_apps_directory + entry.target %}
+
+{{ directory }}/files/nginx-security.conf:
   file.managed:
     - contents: |
        server_tokens off;

--- a/salt/redash/init.sls
+++ b/salt/redash/init.sls
@@ -1,0 +1,12 @@
+include:
+  - docker_apps
+
+/data/deploy/redash/files/nginx-security.conf:
+  file.managed:
+    - contents: |
+       server_tokens off;
+    - user: {{ pillar.docker.user }}
+    - group: {{ pillar.docker.user }}
+    - makedirs: True
+    - require:
+      - user: {{ pillar.docker.user }}_user_exists

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -51,7 +51,7 @@ base:
     - prometheus
 
   'redash':
-    - docker_apps
+    - redash
 
   'redmine':
     - redmine


### PR DESCRIPTION
@jpmckinney, do we have any standardisation around config file names?

This config file needs to be applied after the other files because it overwrites some of their settings – thus zz-customization.
