### PR TITLE
Apache default improvements

### DIFF
--- a/salt/apache/files/sites/_common.conf
+++ b/salt/apache/files/sites/_common.conf
@@ -34,5 +34,12 @@
     {%- if port == 443 or not ssl or not servername %}
     Include {{ includefile }}
     {%- endif %}
+
+    {%- if not servername and ssl and port == 80 %}
+    <IfModule mod_rewrite.c>
+      RewriteEngine On
+      RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+    </IfModule>
+    {%- endif %}
 </VirtualHost>
 {%- endfor %}

--- a/salt/apache/files/sites/default.conf.include
+++ b/salt/apache/files/sites/default.conf.include
@@ -8,6 +8,10 @@ ErrorDocument 403 /404.html
 ErrorLog ${APACHE_LOG_DIR}/error.log
 CustomLog ${APACHE_LOG_DIR}/access.log combined
 
+Header set Content-Security-Policy "frame-ancestors 'none'"
+Header set X-Content-Type-Options "nosniff"
+Header set X-Frame-Options "DENY"
+
 {%- if salt['pillar.get']('apache:modules:mod_autoindex:enabled') %}
 <Directory /var/www/html>
     Options -Indexes

--- a/salt/apache/init.sls
+++ b/salt/apache/init.sls
@@ -61,7 +61,8 @@ apache2-utils:
   file.managed:
     - source: salt://apache/files/404.html
 
-{{ apache('default', {'configuration': 'default', 'servername': ''}) }}
+# Ensure this configuration is loaded first.
+{{ apache('00-default', {'configuration': 'default', 'servername': ''}) }}
 
 {% if salt['pillar.get']('apache:modules:mod_autoindex:enabled') %}
 autoindex:

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -74,6 +74,8 @@ base:
   # All public web servers should use SSL certificates.
   'I@apache:public_access:true':
     - apache.letsencrypt
+    # Enable HTTPS redirects on the default site.
+    - apache.modules.rewrite
 
   'I@redmine:backup':
     - redmine.backup

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -74,6 +74,8 @@ base:
   # All public web servers should use SSL certificates.
   'I@apache:public_access:true':
     - apache.letsencrypt
+    # Enable response headers on the default site.
+    - apache.modules.headers
     # Enable HTTPS redirects on the default site.
     - apache.modules.rewrite
 


### PR DESCRIPTION
The default site config needs to be the first site in-order to apply correctly.
If the default site is not first then another site will return to "unexpected traffic" such as direct requests to the IP address.
This bug exists on Cove because cove is first alphabetically.

- [ ] Delete default.conf in sites-enabled and file in sites-available 