### PR TITLE
Ubuntu 24.04 support

### DIFF
--- a/docs/deploy/create_server.rst
+++ b/docs/deploy/create_server.rst
@@ -32,8 +32,8 @@ Create the server via the :ref:`host<hosting>`'s interface.
       #. `Log into Linode <https://login.linode.com/login>`__
       #. Click *Create Linode*
 
-         #. Set *Images* to the latest Ubuntu LTS version
-         #. Set *Region* to *London UK*
+         #. Set *Linux Distribution* to the latest Ubuntu LTS version
+         #. Set *Region* to *London, UK (eu-west)*
          #. Select a *Linode Plan*
          #. Set *Linode Label* to the server's FQDN (e.g. ``ocp42.open-contracting.org``)
          #. Set *Add Tags* to either *Production* or *Development*
@@ -47,6 +47,7 @@ Create the server via the :ref:`host<hosting>`'s interface.
          #. Click *Power Off* and wait for the server to power off
          #. On the *Storage* tab:
 
+            #. Resize the "Ubuntu ##.04 LTS Disk" disk to the desired size (recommended minimum 20 GB / 20480 MB)
             #. Resize the "Swap Image" disk to the appropriate size
 
                The swap size should be at most 200% of RAM and:
@@ -60,7 +61,6 @@ Create the server via the :ref:`host<hosting>`'s interface.
                   If the swap image is too small, a swap file is `configured <https://github.com/open-contracting/deploy/blob/main/salt/core/swap.sls>`__ by Salt.
 
             #. Rename the "Swap Image" disk to "### MB Swap Image"
-            #. Resize the "Ubuntu ##.04 LTS Disk" disk to the desired size (recommended minimum 20 GB / 20480 MB)
 
          #. On the *Configurations* tab:
 

--- a/salt/core/firewall/files/firewall.sh
+++ b/salt/core/firewall/files/firewall.sh
@@ -61,7 +61,7 @@ fi
 
 echo_verbose "Get iptables location"
 case "${ID}_${VERSION_ID}" in
-ubuntu_22.04 | ubuntu_20.04 | ubuntu_18.04 | debian_10 | debian_9 | debian_8)
+ubuntu_24.04 | ubuntu_22.04 | ubuntu_20.04 | ubuntu_18.04 | debian_10 | debian_9 | debian_8)
     IPTABLESSAVLOC=/etc/iptables/rules.v4
     IP6TABLESSAVLOC=/etc/iptables/rules.v6
     ;;

--- a/salt/core/motd.sls
+++ b/salt/core/motd.sls
@@ -4,7 +4,6 @@ disable default motds:
   file.managed:
     - names:
       - /etc/update-motd.d/10-help-text
-      - /etc/update-motd.d/80-livepatch
     - mode: 644
 
 /etc/default/motd-news:

--- a/salt/core/systemd/ntp.sls
+++ b/salt/core/systemd/ntp.sls
@@ -28,11 +28,6 @@ systemd-timesyncd:
     - watch_in:
       - service: systemd-timesyncd
 
-# Prevent NTP from running at the same time as SNTP.
-ntp:
-  service.dead:
-    - enable: False
-
 set timezone to utc:
   timezone.system:
     - name: UTC


### PR DESCRIPTION
Minor changes preparing Deploy for Ubuntu 24.04.

After deploying, we can delete the following file `/etc/update-motd.d/80-livepatch` on all servers.
This file is no longer present on new installs, however and Salt was creating it as part of the file.managed state.