### PR TITLE
credere: use new format for running commands

### DIFF
--- a/salt/credere/init.sls
+++ b/salt/credere/init.sls
@@ -13,7 +13,7 @@ include:
 {{ set_cron_env(pillar.docker.user, 'MAILTO', 'sysadmin@open-contracting.org') }}
 
 {% for job in entry.cron|default([]) %}
-cd {{ directory }}; /usr/bin/docker compose --progress=quiet run --rm --name credere-backend-{{ job.command }} cron python -m app -v -q {{ job.command }}:
+cd {{ directory }}; /usr/bin/docker compose --progress=quiet run --rm --name credere-backend-{{ job.command }} cron python -m app -q {{ job.command }}:
   cron.present:
     - identifier: CREDERE_{{ job.identifier }}
     - user: {{ pillar.docker.user }}

--- a/salt/credere/init.sls
+++ b/salt/credere/init.sls
@@ -13,7 +13,7 @@ include:
 {{ set_cron_env(pillar.docker.user, 'MAILTO', 'sysadmin@open-contracting.org') }}
 
 {% for job in entry.cron|default([]) %}
-cd {{ directory }}; /usr/bin/docker compose --progress=quiet run --rm --name credere-backend-{{ job.command }} cron python -m app.commands {{ job.command }}:
+cd {{ directory }}; /usr/bin/docker compose --progress=quiet run --rm --name credere-backend-{{ job.command }} cron python -m app -v -q {{ job.command }}:
   cron.present:
     - identifier: CREDERE_{{ job.identifier }}
     - user: {{ pillar.docker.user }}


### PR DESCRIPTION
to be merged with https://github.com/open-contracting/credere-backend/pull/380 and https://github.com/open-contracting/credere-backend/pull/381