### PR TITLE
docs: note salt Python 3.12 bug

### DIFF
--- a/docs/deploy/create_server.rst
+++ b/docs/deploy/create_server.rst
@@ -513,6 +513,16 @@ Configure reverse DNS
 
       The server's Pillar file needs ``system_contacts``, ``network.domain``, ``ssh.admin``, ``locale``, ``ntp`` and, preferably, ``maintenance`` sections.
 
+   .. warning::
+
+      Salt deployments between Python 3.12 systems are `currently broken <https://github.com/saltstack/salt/issues/65360>`__, returning the error message: `ModuleNotFoundError: No module named 'backports'`.
+      To work around this, connect to the new server over SSH and install the `backports.ssl_match_hostname` package.
+
+      .. code-block:: bash
+
+         pip3 install backports.ssl_match_hostname --break-system-packages
+
+
 #. If a disk is larger than 100 GB, :ref:`reduce reserve space<rescale-reserved-space>`.
 #. `Reboot the server <https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.system.html#salt.modules.system.reboot>`__:
 

--- a/docs/deploy/create_server.rst
+++ b/docs/deploy/create_server.rst
@@ -513,16 +513,19 @@ Configure reverse DNS
 
       The server's Pillar file needs ``system_contacts``, ``network.domain``, ``ssh.admin``, ``locale``, ``ntp`` and, preferably, ``maintenance`` sections.
 
-   .. warning::
+   .. tip::
 
-      Salt deployments between Python 3.12 systems are `currently broken <https://github.com/saltstack/salt/issues/65360>`__, returning the error message: `ModuleNotFoundError: No module named 'backports'`.
-      To work around this, connect to the new server over SSH and install the `backports.ssl_match_hostname` package.
+      If you get the error message:
+      
+      .. code-block:: none
+      
+         ModuleNotFoundError: No module named 'backports'
+
+      Try connecting to the server and `running <https://github.com/saltstack/salt/issues/65360#issuecomment-1839127208>`:
 
       .. code-block:: bash
 
          pip3 install backports.ssl_match_hostname --break-system-packages
-
-
 #. If a disk is larger than 100 GB, :ref:`reduce reserve space<rescale-reserved-space>`.
 #. `Reboot the server <https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.system.html#salt.modules.system.reboot>`__:
 


### PR DESCRIPTION
@jpmckinney , just documenting a manual step I ran on `ocp27`.
Salt doesn't yet support Python 3.12 and needs the below workaround for deployments to work.

This bug only occurs for me on `ocp27` and only after upgrading my PC (both systems are now Ubuntu 24.04 and therefore Python 3.12).

Let me know if this is best documented somewhere else.