### PR TITLE
feat: add mysql user host

### DIFF
--- a/pillar/digitalbuying.sls
+++ b/pillar/digitalbuying.sls
@@ -12,6 +12,7 @@ mysql:
   databases:
     digitalbuying:
       user: digitalbuying
+      host: "172.17.%"
 
 docker_apps:
   digitalbuying:

--- a/salt/mysql/init.sls
+++ b/salt/mysql/init.sls
@@ -61,6 +61,9 @@ remove test database:
 {% if 'password' in entry %}
     - password: "{{ entry.password }}"
 {% endif %}
+{% if 'host' in entry %}
+    - host: "{{ entry.host }}"
+{% endif %}
     - require:
       - service: mysql
 {% endfor %} {# users #}
@@ -77,6 +80,9 @@ grant {{ entry.user }} privileges:
     - grant: all privileges
     - database: {{ database }}.*
     - user: {{ entry.user }}
+{% if 'host' in entry %}
+    - host: "{{ entry.host }}"
+{% endif %}
     - require:
       - mysql_user: {{ entry.user }}_mysql_user
       - mysql_database: {{ database }}_mysql_database


### PR DESCRIPTION
Resolves #540

> [T]o finish configuring the digitalbuying app on ocp21, I need MySQL to accept connections from the Docker container.

Docker provisions a private IP range on the host for networking between containers (Using the `172.16.0.0/12` range by default). 
When the digitalbuying app connects to MySQL it appears as one of these private IP addresses, not localhost. 

You can view the digitalbuying network with the following command.
```
docker network inspect digitalbuying_default
```

This PR allows us to configure the MySQL user host in pillar.
I have allowed digitalbuying to connect over the entire private IP range as its IP range will change dynamically when networks are created and destroyed.

- [ ] Test the app works with these changes
- [ ] Document the `host` option
- [ ] Merge