### PR TITLE
feat: add postfix relay support

### DIFF
--- a/pillar/common.sls
+++ b/pillar/common.sls
@@ -31,5 +31,8 @@ ntp:
   - 2.uk.pool.ntp.org
   - 3.uk.pool.ntp.org
 
+smtp:
+  relay: False
+
 netdata:
   enabled: False

--- a/pillar/portland_dev.sls
+++ b/pillar/portland_dev.sls
@@ -1,7 +1,3 @@
-smtp:
-  host: email-smtp.us-west-2.amazonaws.com
-  port: 587
-
 network:
   host_id: ocp26
   ipv4: 20.106.239.92

--- a/pillar/portland_dev.sls
+++ b/pillar/portland_dev.sls
@@ -1,3 +1,7 @@
+smtp:
+  host: email-smtp.us-west-2.amazonaws.com
+  port: 587
+
 network:
   host_id: ocp26
   ipv4: 20.106.239.92

--- a/pillar/portland_dev.sls
+++ b/pillar/portland_dev.sls
@@ -1,3 +1,6 @@
+smtp:
+  relay: True
+
 network:
   host_id: ocp26
   ipv4: 20.106.239.92

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -50,6 +50,7 @@ base:
   'portland-dev':
     - portland_dev
     - docker
+    - private.smtp
 
   'prometheus':
     - prometheus_server

--- a/salt/core/mail.sls
+++ b/salt/core/mail.sls
@@ -23,6 +23,38 @@ postfix:
       - pkg: postfix
     - onchanges:
       - debconf: postfix
+  file.keyvalue:
+    - name: /etc/postfix/main.cf
+    - key_values:
+        # On first run, myhostname may default to previous ISP value.
+        myhostname: "{{ pillar.network.host_id }}.{{ pillar.network.domain }}"
+{%- if 'smtp' in pillar %}
+        relayhost: "[{{ pillar.smtp.host }}]:{{ pillar.smtp.port }}"
+        smtp_sasl_auth_enable: "yes"
+        smtp_sasl_security_options: "noanonymous"
+        smtp_sasl_password_maps: "hash:/etc/postfix/sasl_passwd"
+        smtp_use_tls: "yes"
+        smtp_tls_note_starttls_offer: "yes"
+{%- endif %}
+    - separator: ' = '
+    - append_if_not_found: True
+    - watch_in:
+      - service: postfix
+
+{% if 'smtp' in pillar %}
+/etc/postfix/sasl_passwd:
+  file.managed:
+    - contents: "[{{ pillar.smtp.host }}]:{{ pillar.smtp.port }} {{ pillar.smtp.username }}:{{ pillar.smtp.password }}"
+    - mode: 600
+  cmd.run:
+    - name: postmap hash:/etc/postfix/sasl_passwd
+    - require:
+      - pkg: postfix
+    - onchanges:
+      - file: /etc/postfix/sasl_passwd
+    - watch_in:
+      - file: postfix
+{% endif %}
 
 # Install commands for users to interact with mail.
 mailutils:

--- a/salt/core/mail.sls
+++ b/salt/core/mail.sls
@@ -28,7 +28,7 @@ postfix:
     - key_values:
         # On first run, myhostname may default to previous ISP value.
         myhostname: "{{ pillar.network.host_id }}.{{ pillar.network.domain }}"
-{%- if 'smtp' in pillar %}
+{%- if 'relay' in pillar.smtp and pillar.smtp.relay == True %}
         relayhost: "[{{ pillar.smtp.host }}]:{{ pillar.smtp.port }}"
         smtp_sasl_auth_enable: "yes"
         smtp_sasl_security_options: "noanonymous"
@@ -41,7 +41,7 @@ postfix:
     - watch_in:
       - service: postfix
 
-{% if 'smtp' in pillar %}
+{%- if 'relay' in pillar.smtp and pillar.smtp.relay == True %}
 /etc/postfix/sasl_passwd:
   file.managed:
     - contents: "[{{ pillar.smtp.host }}]:{{ pillar.smtp.port }} {{ pillar.smtp.username }}:{{ pillar.smtp.password }}"

--- a/salt/core/mail.sls
+++ b/salt/core/mail.sls
@@ -28,7 +28,7 @@ postfix:
     - key_values:
         # On first run, myhostname may default to previous ISP value.
         myhostname: "{{ pillar.network.host_id }}.{{ pillar.network.domain }}"
-{%- if 'relay' in pillar.smtp and pillar.smtp.relay == True %}
+{%- if pillar.smtp.relay %}
         relayhost: "[{{ pillar.smtp.host }}]:{{ pillar.smtp.port }}"
         smtp_sasl_auth_enable: "yes"
         smtp_sasl_security_options: "noanonymous"
@@ -41,7 +41,7 @@ postfix:
     - watch_in:
       - service: postfix
 
-{%- if 'relay' in pillar.smtp and pillar.smtp.relay == True %}
+{%- if pillar.smtp.relay %}
 /etc/postfix/sasl_passwd:
   file.managed:
     - contents: "[{{ pillar.smtp.host }}]:{{ pillar.smtp.port }} {{ pillar.smtp.username }}:{{ pillar.smtp.password }}"

--- a/salt/prometheus/files/conf-alertmanager.yml
+++ b/salt/prometheus/files/conf-alertmanager.yml
@@ -27,7 +27,7 @@ receivers:
         smarthost: {{ pillar.smtp.host }}:{{ pillar.smtp.port }}
         auth_username: {{ pillar.smtp.username }}
         auth_password: {{ pillar.smtp.password }}
-        require_tls: {{ pillar.smtp.tls }}
+        require_tls: True
         send_resolved: True
   - name: rh-email
     email_configs:
@@ -36,5 +36,5 @@ receivers:
         smarthost: {{ pillar.smtp.host }}:{{ pillar.smtp.port }}
         auth_username: {{ pillar.smtp.username }}
         auth_password: {{ pillar.smtp.password }}
-        require_tls: {{ pillar.smtp.tls }}
+        require_tls: True
         send_resolved: True


### PR DESCRIPTION
This PR adds relay support to Postfix. We need this on portland-dev in order to send administrative email as they are being blocked by the ISP.

@jpmckinney , `pillar.smtp` is already configured on Credere, but I cannot see where it is in use in Salt?
I re-used `smtp` because it configures the same service this adds to Postfix.
However, if this clashes other parts of the code, we could rename the values in this PR to `pillar.postfix.relay`.

To Do:
- [ ] Create SMTP credentials and add to pillar private ([docs](https://ocdsdeploy.readthedocs.io/en/latest/deploy/services/aws.html#create-smtp-credentials))
- [ ] Merge and deploy to portland-dev
