### PR TITLE
Sysctl redis

### DIFF
--- a/docs/develop/update/docker.rst
+++ b/docs/develop/update/docker.rst
@@ -113,6 +113,16 @@ Reference:
 -  `Compose specification <https://docs.docker.com/compose/compose-file/>`__
 -  `Use Compose in production <https://docs.docker.com/compose/production/>`__
 
+Redis
+~~~~~
+
+If the Docker Compose file describes a Redis service, add, in the server's Pillar file:
+
+.. code-block:: yaml
+
+   vm:
+     overcommit_memory: 1
+
 Configure Docker app
 --------------------
 

--- a/pillar/cms.sls
+++ b/pillar/cms.sls
@@ -10,6 +10,9 @@ network:
     template: linode
     gateway4: 139.162.211.1
 
+vm:
+  overcommit_memory: 1
+
 logrotate:
   conf:
     php-site-logs:

--- a/pillar/cms.sls
+++ b/pillar/cms.sls
@@ -11,6 +11,7 @@ network:
     gateway4: 139.162.211.1
 
 vm:
+  # For Redis service in digitalbuying.yaml.
   overcommit_memory: 1
 
 logrotate:

--- a/pillar/common.sls
+++ b/pillar/common.sls
@@ -36,3 +36,10 @@ smtp:
 
 netdata:
   enabled: False
+
+vm:
+{% if grains.mem_total > 2048 %}
+  swappiness: 10
+{% else %}
+  swappiness: 40
+{% endif %}

--- a/pillar/cove.sls
+++ b/pillar/cove.sls
@@ -18,6 +18,9 @@ network:
     template: linode
     gateway4: 176.58.107.1
 
+vm:
+  overcommit_memory: 1
+
 apache:
   public_access: True
   sites:

--- a/pillar/cove.sls
+++ b/pillar/cove.sls
@@ -19,6 +19,7 @@ network:
     gateway4: 176.58.107.1
 
 vm:
+  # For Redis service in cove.yaml.
   overcommit_memory: 1
 
 apache:

--- a/pillar/dreambi.sls
+++ b/pillar/dreambi.sls
@@ -3,6 +3,9 @@ network:
   ipv4: 5.75.247.51
   ipv6: 2a01:4f8:c012:3ea8::1
 
+vm:
+  overcommit_memory: 1
+
 ssh:
   dreambi:
     # RBC Group

--- a/pillar/dreambi.sls
+++ b/pillar/dreambi.sls
@@ -4,6 +4,7 @@ network:
   ipv6: 2a01:4f8:c012:3ea8::1
 
 vm:
+  # For Redis service in qlikauth.yaml.
   overcommit_memory: 1
 
 ssh:

--- a/pillar/registry.sls
+++ b/pillar/registry.sls
@@ -32,6 +32,7 @@ network:
 
 vm:
   nr_hugepages: 8231
+  overcommit_memory: 1
 
 ntp:
   - 0.fi.pool.ntp.org

--- a/pillar/registry.sls
+++ b/pillar/registry.sls
@@ -31,7 +31,9 @@ network:
                 - 2620:119:35::35
 
 vm:
+  # https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-HUGE-PAGES
   nr_hugepages: 8231
+  # For Redis service in spoonbill.yaml.
   overcommit_memory: 1
 
 ntp:

--- a/salt/core/swap.sls
+++ b/salt/core/swap.sls
@@ -29,9 +29,3 @@
   mount.swap:
     - persist: True
 {% endif %}
-
-# Set swappiness so that it is only used when memory is full.
-vm.swappiness:
-  sysctl.present:
-    - config: /etc/sysctl.d/99-swappiness.conf
-    - value: {{ vm_swappiness }}

--- a/salt/core/sysctl.sls
+++ b/salt/core/sysctl.sls
@@ -1,0 +1,22 @@
+{% set exclude_list = ['overcommit_memory'] %}
+{% for name, value in salt['pillar.get']('vm', {}) | items | rejectattr("0", "in", exclude_list) %}
+vm.{{name}}:
+  sysctl.present:
+    - value: {{ value }}
+{% endfor %}
+
+# https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
+# https://github.com/open-contracting/deploy/issues/524
+{% if salt['pillar.get']('vm:overcommit_memory') %}
+{% set vm_overcommit_memory = pillar.vm.overcommit_memory %}
+{% elif salt['pillar.get']('redis') %}
+{% set vm_overcommit_memory = 1 %}
+{% elif salt['pillar.get']('postgres') %}
+{% set vm_overcommit_memory = 2 %}
+{% endif %}
+
+{% if vm_overcommit_memory %}
+vm.overcommit_memory:
+  sysctl.present:
+    - value: {{ vm_overcommit_memory }}
+{% endif %}

--- a/salt/core/sysctl.sls
+++ b/salt/core/sysctl.sls
@@ -1,17 +1,19 @@
-{% set exclude_list = ['overcommit_memory'] %}
-{% for name, value in salt['pillar.get']('vm', {}) | items | rejectattr("0", "in", exclude_list) %}
-vm.{{name}}:
+{% for name, value in salt['pillar.get']('vm', {})|items %}
+{% if name != 'overcommit_memory' %}
+vm.{{ name }}:
   sysctl.present:
     - value: {{ value }}
+{% endif %}
 {% endfor %}
 
-# https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
 # https://github.com/open-contracting/deploy/issues/524
 {% if salt['pillar.get']('vm:overcommit_memory') %}
 {% set vm_overcommit_memory = pillar.vm.overcommit_memory %}
 {% elif salt['pillar.get']('redis') %}
+# https://redis.io/docs/latest/operate/oss_and_stack/management/admin/
 {% set vm_overcommit_memory = 1 %}
 {% elif salt['pillar.get']('postgres') %}
+# https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
 {% set vm_overcommit_memory = 2 %}
 {% endif %}
 

--- a/salt/core/sysctl.sls
+++ b/salt/core/sysctl.sls
@@ -17,7 +17,7 @@ vm.{{ name }}:
 {% set vm_overcommit_memory = 2 %}
 {% endif %}
 
-{% if vm_overcommit_memory %}
+{% if vm_overcommit_memory is defined %}
 vm.overcommit_memory:
   sysctl.present:
     - value: {{ vm_overcommit_memory }}

--- a/salt/postgres/init.sls
+++ b/salt/postgres/init.sls
@@ -61,20 +61,6 @@ postgres_authorized_keys:
       - pkg: postgresql
 {% endif %}
 
-# https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
-# https://github.com/jfcoz/postgresqltuner
-vm.overcommit_memory:
-  sysctl.present:
-    - value: {{ salt['pillar.get']('vm:overcommit_memory', 2) }}
-
-# https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-HUGE-PAGES
-# https://github.com/jfcoz/postgresqltuner
-{% if salt['pillar.get']('vm:nr_hugepages') %}
-vm.nr_hugepages:
-  sysctl.present:
-    - value: {{ pillar.vm.nr_hugepages }}
-{% endif %}
-
 pgbadger:
   pkg.installed:
     - name: pgbadger

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -16,6 +16,7 @@ base:
     - core.rsyslog
     - core.sshd
     - core.swap
+    - core.sysctl
     - core.systemd.logind
     - core.systemd.ntp
 


### PR DESCRIPTION
We are now configuring more kernel parameters with sysctl and for multiple services. This PR consolidates the setting of kernel parameters into one, dynamic core file.
This function needed extracting because `overcommit_memory` should be configured for both Redis and PostgreSQL.

@jpmckinney , I think, it would be beneficial to add a prompt in the docs to configure `overcommit_memory` when Redis containers in Docker are added. I am not sure where to add this, or how big of a section it should be, please can you advise?

Once merged, the following needs actioning:
- [ ] Remove `/etc/sysctl.d/99-swappiness.conf`

Closes #524 