### PR TITLE
feat: unifying backup date format

### DIFF
--- a/salt/backup/files/site-backup-to-s3.sh
+++ b/salt/backup/files/site-backup-to-s3.sh
@@ -30,7 +30,7 @@ for DIRECTORY in "${BACKUP_DIRECTORIES[@]}"; do
     SAFENAME="${DIRECTORY//[^a-zA-Z0-9]/_}"
     SAFENAME="${SAFENAME/#_/}"
     SAFENAME="${SAFENAME/%_/}"
-    BASENAME="${SAFENAME}_backup_$(TZ=UTC date +%Y-%m-%d).tar.gz"
+    BASENAME="${SAFENAME}_backup_$(TZ=UTC date +%Y%m%dT%H%M%SZ).tar.gz"
     TEMPFILE="$(mktemp /tmp/site_backup_XXXX.tar.gz)"
 
     # tar will return an exit code if a file is changed (e.g. log) or removed (e.g. cache).

--- a/salt/mysql/files/mysql-backup-to-s3.sh
+++ b/salt/mysql/files/mysql-backup-to-s3.sh
@@ -32,7 +32,7 @@ for DATABASE in "${DATABASES[@]}"; do
     case "$DATABASE" in
     information_schema | performance_schema | sys | innodb | mysql) ;; # Skip system databases
     *)
-        BASENAME="$(TZ=UTC date +%Y-%m-%d_%H:%M:%S)_$DATABASE.sql.gz"
+        BASENAME="$(TZ=UTC date +%Y%m%dT%H%M%SZ)_$DATABASE.sql.gz"
         TEMPFILE="$(mktemp /tmp/mysql_backup_XXXX.sql.gz)"
 
         /usr/bin/mysqldump --defaults-extra-file=/home/sysadmin-tools/mysql-defaults.cnf --databases "$DATABASE" | gzip > "$TEMPFILE"

--- a/salt/postgres/files/postgres-backup-to-s3.sh
+++ b/salt/postgres/files/postgres-backup-to-s3.sh
@@ -25,7 +25,7 @@ mapfile -t DATABASES < <(su - postgres -c "/usr/bin/psql -t --csv -c 'select dat
 
 for DATABASE in "${BACKUP_DATABASES[@]}"; do
     if [[ "${DATABASES[*]}" =~ $DATABASE ]]; then
-        BASENAME="$(TZ=UTC date +%Y-%m-%d_%H:%M:%S)_$DATABASE.tar"
+        BASENAME="$(TZ=UTC date +%Y%m%dT%H%M%SZ)_$DATABASE.tar"
         TEMPFILE="$(mktemp /tmp/postgres_backup_XXXX.tar)"
         chown postgres:postgres "$TEMPFILE"
 


### PR DESCRIPTION
The `tar` command interprets colons in filenames as a remote server to connect too.
This quirk of tar meant that working with our PostgreSQL backups was not straightforward, and importantly, could delay recovery in critical moments.

This PR changes backup file date formats to only include a basic character set while still following iso 8601 standardisation.

I have also added the time to file backups allowing us to backup multiple times in one day.