### PR TITLE
Change SSL verification method

### DIFF
--- a/salt/apache/files/conf/letsencrypt.conf
+++ b/salt/apache/files/conf/letsencrypt.conf
@@ -1,6 +1,7 @@
 <IfModule md_module>
     MDContactEmail sysadmin@open-contracting.org
     MDCertificateAgreement accepted
+    MDCAChallenges http-01
 {%- for directive, value in salt['pillar.get']('apache:modules:mod_md', {})|items %}
     {{ directive }} {{ value }}
 {%- endfor %}


### PR DESCRIPTION
SSL renewals fail following the implementation of Cloudflare. This PR modifies the challenge method to fix this.

The default challenge method is `tls-alpn`, ALPN traffic is not passed through by the proxy causing SSL renewals to fail.

There are two alternatives:
* HTTP authentication - mod_md manages requests to a custom path (`/.acme-challenge/[...]`) to authenticate certificates. HTTP authentication is the quickest to set up.
* DNS authentication - mod_md talks directly to our DNS provider and authenticates certificates there. This is potentially more reliable and scalable.

https://httpd.apache.org/docs/2.4/mod/mod_md.html#mdcachallenges

DNS authentication is preferred but it needs more set up for the same result.


I have deployed this PR to ocp19 in order to renew the standard.open-contracting.org SSL certificate as it would expire over the holiday period.
* Also deployed on ocp23 / Kingfisher.

Note: After deploying, Apache needed restarting twice - once to generate new certificates and a second time to load them in.


