### PR TITLE
Upgrade PostgreSQL adapter from psycopg2 to psycopg (psycopg 3)

### DIFF
--- a/docs/use/databases.rst
+++ b/docs/use/databases.rst
@@ -122,15 +122,15 @@ Python
 
 `Python <https://www.python.org>`__ is the programming language in which many OCDS tools are written.
 
-Install the `psycopg2 <https://pypi.org/project/psycopg2/>`__ Python package.
+Install the `psycopg <https://pypi.org/project/psycopg/>`__ Python package.
 
 For security, remember to set ``sslmode`` to ``'require'``.
 
 .. code-block:: python
 
-   import psycopg2
+   import psycopg
 
-   conn = psycopg2.connect(
+   conn = psycopg.connect(
        dbname='kingfisher_process',
        user='USER',
        password='PASSWORD',

--- a/salt/kingfisher/collect/incremental.sls
+++ b/salt/kingfisher/collect/incremental.sls
@@ -1,7 +1,7 @@
 {% from 'lib.sls' import create_user, set_cron_env %}
 
 include:
-  - python.psycopg2
+  - python.psycopg
   - python_apps
 
 {% set entry = pillar.python_apps.kingfisher_collect %}

--- a/salt/kingfisher/collect/init.sls
+++ b/salt/kingfisher/collect/init.sls
@@ -3,7 +3,7 @@
 include:
   - python.virtualenv
   - python.extensions # twisted
-  - python.psycopg2
+  - python.psycopg
 
 {% set entry = pillar.kingfisher_collect %}
 {% set user = entry.user %}

--- a/salt/kingfisher/summarize/init.sls
+++ b/salt/kingfisher/summarize/init.sls
@@ -1,7 +1,7 @@
 {% from 'lib.sls' import create_user, set_cron_env %}
 
 include:
-  - python.psycopg2
+  - python.psycopg
   - python_apps
 
 {% set entry = pillar.python_apps.kingfisher_summarize %}

--- a/salt/python/psycopg.sls
+++ b/salt/python/psycopg.sls
@@ -1,8 +1,8 @@
 include:
   - python
 
-# https://www.psycopg.org/install/
-psycopg2:
+# https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation
+psycopg:
   pkg.installed:
     - pkgs:
       - python{{ salt['pillar.get']('python:version', 3) }}-dev


### PR DESCRIPTION
Rename the python.psycopg2 Salt state to python.psycopg and update its
includes in the kingfisher collect, incremental and summarize states. The
state installs the same build dependencies (python-dev, libpq-dev) required
to compile psycopg[c] from source in production.

Update the databases usage docs to import psycopg and call psycopg.connect().

Ref: open-contracting/software-development-handbook#162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HfBXUB6Rgvqws9h7w7v9sP