### PR TITLE
feat: restart scrapyd on failure

### DIFF
--- a/salt/core/systemd/files/scrapyd.service
+++ b/salt/core/systemd/files/scrapyd.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Scrapyd
 After=network.target
+# https://github.com/open-contracting/deploy/issues/563
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 User={{ user }}
@@ -18,6 +21,9 @@ WorkingDirectory={{ entry.appdir }}
 ExecStart={{ entry.appdir }}/.ve/bin/scrapyd --logfile=/var/log/scrapyd/scrapyd.log
 # https://github.com/open-contracting/kingfisher-collect/issues/606#issuecomment-953896571
 LimitNOFILE=512000
+# https://github.com/open-contracting/deploy/issues/563
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/salt/core/systemd/files/scrapyd.service
+++ b/salt/core/systemd/files/scrapyd.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Scrapyd
 After=network.target
-# https://github.com/open-contracting/deploy/issues/563
-StartLimitInterval=200
+StartLimitIntervalSec=300
 StartLimitBurst=5
 
 [Service]
@@ -19,11 +18,10 @@ Environment="no_proxy=localhost,sentry.io,open-contracting.org"
 {%- endif %}
 WorkingDirectory={{ entry.appdir }}
 ExecStart={{ entry.appdir }}/.ve/bin/scrapyd --logfile=/var/log/scrapyd/scrapyd.log
-# https://github.com/open-contracting/kingfisher-collect/issues/606#issuecomment-953896571
-LimitNOFILE=512000
-# https://github.com/open-contracting/deploy/issues/563
 Restart=on-failure
 RestartSec=30
+# https://github.com/open-contracting/kingfisher-collect/issues/606#issuecomment-953896571
+LimitNOFILE=512000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Resolves #563


I am assuming that Scrapyd returns a non-zero exit code on failure. If this is not the case we can use `Restart=always`
[Further reading](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html?__goaway_challenge=meta-refresh&__goaway_id=5b1df7a2e2758397ae131c033abe1383#Restart=).